### PR TITLE
fix(gitignore): resolve tracked-vs-ignored conflicts, add missing patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled CUDA binaries
 *.cubin
+!*_handtuned.sm_86.cubin
 
 # Generated SASS disassembly (keep hand-tuned variants)
 *.cuasm
@@ -20,12 +21,25 @@ verify_wmma_layout
 __pycache__/
 *.pyc
 
-# Session handoff (ephemeral, not committed)
-CONTINUE_HERE.md
-
 # Third-party tools (clone separately)
 tools/CuAssembler/
 
 # CuAssembler working artifacts
 *.cuasm.orig
+
+# Raw SASS reference (generated on-demand via scripts/build.py)
 *.sass
+
+# Claude Code / context
+.claude/
+
+# IDE / Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Fixes #40

- Remove `CONTINUE_HERE.md` from `.gitignore` — it was tracked in git but also ignored, creating confusion
- Add `.claude/` directory (imported context/conversation state)
- Add hand-tuned cubin exception: `!*_handtuned.sm_86.cubin`
- Add IDE patterns (`.vscode/`, `.idea/`, `*.swp`)
- Add OS patterns (`.DS_Store`, `Thumbs.db`)
