### PR TITLE
docs: WSL-first setup guide + README consolidation with current results

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ Run `python scripts/verify_setup.py` to confirm everything is working.
 | 2 | ML primitives: SGEMM, HGEMM, softmax, layernorm, activations | ✅ Done | 7,853 GFLOPS HGEMM via HMMA.16816.F32 |
 | 3 | Flash Attention: scalar → 4-warp → Br=16 HMMA (19× speedup) | ✅ Done | 2.8 ms at seq=1024 with Tensor Cores |
 | 4 | Diffusion UNet: timestep emb, GroupNorm, Conv2d, ResNet, cross-attn | ✅ Done | Full SASS primitive inventory |
+| 5 | Sparse GEMM, INT8 quantization, optimized epilogues | ✅ Done | 41,930 sparse-equiv GFLOPS |
+
+## Phase 5 — Sparse & Quantized GEMM (Complete)
+
+| Kernel | Highlight | Peak Result |
+|--------|-----------|-------------|
+| Sparse HGEMM 2:4 | `mma.sp` with ldmatrix | 41,930 dense-equiv GFLOPS |
+| Sparse IGEMM 2:4 | INT8 sparse Tensor Cores | 39,745 dense-equiv TOPS at 2048³ |
+| Online FP16→INT8 | Quantize on-the-fly in kernel | 16,646 GFLOPS (2.1× vs naive HGEMM) |
+| Bank-conflict-free INT8 | Optimized smem epilogue | 17,070 GFLOPS |
+
+> Phase 5 represents the optimization frontier: sparse patterns, INT8 quantization, and tuned epilogues. See [`docs/gpu_reflections.md`](docs/gpu_reflections.md) for the full empirical analysis.
+
+## Current Best Results (RTX 3070 Ti Laptop)
+
+### GEMM
+| Kernel | Size | Performance | % Peak |
+|--------|------|-------------|--------|
+| HGEMM 16-warp | 4096³ | **31,910 GFLOPS** | 18.3% |
+| HGEMM sparse 2:4 | 2048³ | **41,930** dense-equiv GFLOPS | — |
+| IGEMM pipelined cp.async | 4096³ | **20,688 TOPS** | 3.0% |
+| IGEMM 128×256 (1 blk/SM) | 4096³ | **27,591 TOPS** | 4.0% |
+| Online FP16→INT8 quant | 4096³ | **16,646 GFLOPS** | 9.6% |
+
+### Flash Attention
+| Kernel | Config | Time | GFLOPS |
+|--------|--------|------|--------|
+| Flash Attention Br=16 regpv | seq=1024, b=8, h=8 | **2.81 ms** | **6,112** |
+
+### Diffusion UNet
+| Kernel | Config | Time | Performance |
+|--------|--------|------|-------------|
+| Implicit GEMM conv2d | 64×64, Cin=Cout=320 | **1.13 ms** | **6,687 GFLOPS** |
 
 ## Phase 4 Results Summary
 
@@ -74,7 +107,8 @@ All components of a Stable Diffusion UNet block implemented and verified:
 | Timestep embedding | `MUFU.SIN`, `MUFU.COS`, `MUFU.EX2` | 153 GB/s at d=512, batch=1024 |
 | GroupNorm (NHWC) | `SHFL.BFLY`, `MUFU.RSQ`, `MUFU.RCP` | 28–74 GB/s |
 | GroupNorm+SiLU fused | above + `MUFU.EX2` for SiLU | reads X once (saves 1 tensor pass) |
-| Conv2d 3×3 NHWC | `FFMA` (310 per pass, 9×unrolled) | 265–299 GFLOPS |
+| Conv2d 3×3 direct | `FFMA` (310 per pass, 9×unrolled) | 265–299 GFLOPS |
+| Conv2d implicit GEMM | `HMMA.16816.F32`, precomputed coords | 6,687 GFLOPS (22× over direct) |
 | ResNet Block | all of the above + `FADD` | 265 GFLOPS at SD 320ch 16×16 |
 | Cross-attention | `HMMA.16816.F32`, `SHFL.BFLY`, `MUFU.EX2` | 2,255 GFLOPS at 32×32 with CLIP-77 |
 

--- a/setup.md
+++ b/setup.md
@@ -1,65 +1,95 @@
 # Environment Setup
 
-## 1. CUDA Toolkit 12.6
+> **Development happens in WSL2.** The Windows NVIDIA driver exposes the GPU to WSL via `/usr/lib/wsl/lib/`. All build scripts, benchmarks, and SASS tooling assume a Linux environment.
 
-Download from: https://developer.nvidia.com/cuda-12-6-0-download-archive
-Select: Windows 11 > x86_64 > exe (local)
+## Quick Start (WSL2 — Recommended)
 
-After install, verify these are on PATH (open a new terminal):
+### 1. Install CUDA Toolkit in WSL
+
+```bash
+# Ubuntu 24.04
+sudo apt update
+sudo apt install nvidia-cuda-toolkit
 ```
+
+Verify:
+```bash
 nvcc --version
 cuobjdump --version
 nvdisasm --version
+nvidia-smi
 ```
 
-Default install path: `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\`
+> **Why CUDA 12.8?** This project targets sm_86 (RTX 3070 Ti). CuAssembler was developed against CUDA 11.x–12.x; the cubin format may differ in 13.x. The driver is forward-compatible, so 12.8 kernels run on newer drivers.
 
-> **Why 12.6 and not 13.x?** CuAssembler was developed against CUDA 11.x/12.x.
-> The cubin format may differ in 13.x. Driver is forward-compatible so 12.6 runs fine.
-
-## 2. Visual Studio 2022 Build Tools
-
-nvcc requires the MSVC C++ compiler (`cl.exe`).
-
-Download: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022
-Workload to select: **Desktop development with C++**
-
-After install, use the **Developer Command Prompt for VS 2022** (or add cl.exe to PATH).
-
-## 3. Python Dependencies
+### 2. Python Dependencies
 
 ```bash
-pip install pyelftools sympy
+python3 -m pip install pyelftools sympy
 ```
 
-## 4. CuAssembler
+If pip warns about PEP 668 (externally managed environment):
+```bash
+python3 -m pip install pyelftools sympy --break-system-packages
+```
+
+### 3. CuAssembler
 
 ```bash
-cd D:\dev\p\bare-metal
 git clone https://github.com/cloudcores/CuAssembler.git tools/CuAssembler
 ```
 
-Add to PYTHONPATH (add to your shell profile or set per-session):
+Add to `~/.bashrc` (or set per-session):
 ```bash
-set PYTHONPATH=D:\dev\p\bare-metal\tools\CuAssembler;%PYTHONPATH%
+export PYTHONPATH="$PWD/tools/CuAssembler:$PYTHONPATH"
 ```
 
-## 5. Verify Everything
+### 4. Verify Everything
 
 ```bash
-cd D:\dev\p\bare-metal
-python scripts/verify_setup.py
+python3 scripts/verify_setup.py
 ```
 
 All checks should pass before proceeding to Phase 1.
 
+---
+
+## Appendix: Native Windows Setup
+
+> ⚠️ **Not recommended.** Use WSL2 unless you have a specific reason to build on Windows natively.
+
+### CUDA Toolkit (Windows)
+Download from: https://developer.nvidia.com/cuda-downloads  
+Default path: `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\`
+
+### Build Tools
+nvcc on Windows requires MSVC (`cl.exe`). Install **Visual Studio 2022 Build Tools** with the **Desktop development with C++** workload, then use the **Developer Command Prompt for VS 2022**.
+
+### PYTHONPATH (Windows cmd)
+```cmd
+set PYTHONPATH=D:\dev\p\bare-metal\tools\CuAssembler;%PYTHONPATH%
+```
+
+---
+
 ## Troubleshooting
 
-**nvcc not found**: Add `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin` to PATH.
+**nvcc not found in WSL**:  
+```bash
+export PATH=/usr/local/cuda/bin:$PATH
+```
+Add to `~/.bashrc` to make permanent.
 
-**cl.exe not found**: Open a Developer Command Prompt for VS 2022, or run:
-`"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"`
+**WSL: GPU detected by `nvidia-smi` but CUDA programs fail**:  
+Check driver/toolkit version compatibility:
+```bash
+cat /proc/driver/nvidia/version   # Windows driver version
+nvcc --version                    # CUDA toolkit version
+```
+The toolkit version must be ≤ the driver's maximum supported CUDA version.
 
-**CuAssembler import fails**: Check PYTHONPATH includes `D:\dev\p\bare-metal\tools\CuAssembler`.
+**CuAssembler import fails**:  
+Ensure `tools/CuAssembler/` is in `sys.path`. `scripts/build.py` and `scripts/verify_setup.py` handle this automatically.
 
-**GPU not detected**: Run `nvidia-smi` — if this fails, reinstall the NVIDIA driver.
+**GPU not detected**:  
+Run `nvidia-smi`. If this fails, reinstall the Windows NVIDIA driver (WSL uses the Windows driver, not a separate Linux driver).


### PR DESCRIPTION
Fixes #39, #44

## setup.md
- Restructured as **WSL2-first** — all scripts and SASS tooling assume Linux
- Native Windows instructions moved to a clearly-marked appendix
- Fixed `PYTHONPATH` to Unix style (`$PWD/tools/CuAssembler`)
- Added CUDA 12.8 compatibility note for CuAssembler
- Removed stale Visual Studio Build Tools / `cl.exe` references

## README.md
- Added **Phase 5** (sparse GEMM, INT8 quantization) to phases table
- Added **"Current Best Results"** section with measured peaks across GEMM, Flash Attention, and Diffusion UNet
- Updated Phase 4 results to include implicit GEMM conv2d (6,687 GFLOPS, 22× over direct)

## Numbers source
All performance figures taken from `docs/gpu_reflections.md` (verified benchmarks on RTX 3070 Ti Laptop, sm_86).
