### PR TITLE
docs: fix CUDA version, add benchmark provenance, reproducible figures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # bare-metal GPU — Top-level Makefile
 #
 # Usage:
-#   make reproduce    — setup + verify + build + bench (full one-stop)
+#   make reproduce    — setup + verify + build + bench + figures (full one-stop)
 #   make setup        — renv::restore() + install local cuasmR R package
 #   make verify       — environment check (CUDA, GPU, cuasmR)
 #   make all          — build all kernel cubins + benchmark executables
@@ -54,7 +54,7 @@ REFERENCE_BENCH    := $(shell find kernels/reference     -name 'bench*.cu' 2>/de
 # Default target
 # ------------------------------------------------------------------
 .PHONY: all cubins benches test clean disasm help \
-        setup verify bench bench-reference compare-reference reference-pipeline reproduce \
+        setup verify bench bench-reference compare-reference reference-pipeline reproduce figures \
         tutorial gemm reductions attention convolution elementwise memory_layout composition reference
 
 all: cubins benches
@@ -162,6 +162,13 @@ verify:
 bench:
 	@$(RSCRIPT) scripts/bench/bench_regress.R
 
+figures:
+	@echo "=== Regenerating docs/figures ==="
+	@$(RSCRIPT) scripts/audit/generate_readme_figures.R
+	@$(RSCRIPT) scripts/profile/roofline_measured.R
+	@$(RSCRIPT) scripts/audit/sass_histogram.R
+	@$(RSCRIPT) scripts/cymatic/cymatic_visualize.R
+
 bench-reference: reference
 	@$(RSCRIPT) scripts/bench/bench_reference.R
 
@@ -170,7 +177,7 @@ compare-reference:
 
 reference-pipeline: reference bench-reference compare-reference
 
-reproduce: setup verify all bench
+reproduce: setup verify all bench figures
 	@echo ""
 	@echo "================================================================"
 	@echo "Full reproduction complete."
@@ -178,6 +185,7 @@ reproduce: setup verify all bench
 	@echo "  verify   -- toolchain + GPU detected"
 	@echo "  all      -- every cubin + bench compiled"
 	@echo "  bench    -- results compared to data/baselines.json"
+	@echo "  figures  -- docs/figures regenerated"
 	@echo "================================================================"
 
 # ------------------------------------------------------------------
@@ -200,10 +208,11 @@ help:
 	@echo "bare-metal GPU build system"
 	@echo ""
 	@echo "Reproducibility:"
-	@echo "  make reproduce — one-stop: setup + verify + build + bench"
+	@echo "  make reproduce — one-stop: setup + verify + build + bench + figures"
 	@echo "  make setup     — renv::restore() + install cuasmR"
 	@echo "  make verify    — environment check (CUDA, GPU, cuasmR)"
 	@echo "  make bench     — run benches vs data/baselines.json"
+	@echo "  make figures   — regenerate docs/figures via R scripts"
 	@echo "  make bench-reference — run local reference benches vs data/reference_baselines.json"
 	@echo "  make compare-reference — compare project baselines to local reference baselines"
 	@echo "  make reference-pipeline — build + validate + compare local reference benches"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ paths).
 
 ## Headline performance
 
+<sub>**Toolchain provenance.** All benchmark tables in this README were measured on RTX 3070 Ti (GA104, sm_86, 46-SM laptop bin), CUDA 13.2 / nvcc V13.2.78, driver 595.97.</sub>
+
 ![Kernel performance overview](docs/figures/performance_overview.png)
 
 Measured GFLOPS across all completed kernels, grouped by precision class.
@@ -233,7 +235,7 @@ Most of this project's "tile size" decisions are dictated by this cliff.
 
 | Tool                   | Purpose                                              |
 |------------------------|------------------------------------------------------|
-| **`nvcc`**             | CUDA compiler (CUDA 12.x)                            |
+| **`nvcc`**             | CUDA compiler (CUDA 13.2)                            |
 | **`cuobjdump -sass`**  | disassemble cubin to SASS                            |
 | **`nvdisasm`**         | raw disassembly with control codes                   |
 | **`cuasmR`** (local R) | byte-level cubin patcher (replaces upstream CuAssembler) |

--- a/docs/tutorial/01-sass-hello-world.md
+++ b/docs/tutorial/01-sass-hello-world.md
@@ -60,7 +60,7 @@ Rscript scripts/build.R roundtrip vector_add.cu               # all three, verif
 
 The roundtrip step is the toolchain smoke test. If it fails, your
 CUDA-CuAssembler version pairing is incompatible — fix that before
-anything else. With CUDA 12.x and the bundled `tools/CuAssembler/`,
+anything else. With CUDA 13.2 and the bundled `tools/CuAssembler/`,
 roundtrip should pass on a fresh checkout.
 
 ## Step 1 — Compile and disassemble

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -37,7 +37,7 @@ The chapters can be read in two ways:
 
 ## Prerequisites
 
-- Working CUDA 12.x install with `nvcc`, `cuobjdump`, `nvdisasm` on PATH
+- Working CUDA 13.2 install with `nvcc`, `cuobjdump`, `nvdisasm` on PATH
 - An sm_86-class GPU (RTX 30-series, RTX A-series, etc.)
 - Familiarity with C++ and basic CUDA programming model (thread, block, warp, smem)
 - Linux or WSL2 environment

--- a/scripts/verify_setup.R
+++ b/scripts/verify_setup.R
@@ -80,7 +80,7 @@ check_cuasmR <- function() {
 }
 
 check_gpu_info <- function() {
-  r <- run_command("nvidia-smi --query-gpu=name,compute_cap,memory.total --format=csv,noheader")
+  r <- run_command("nvidia-smi --query-gpu=name,compute_cap,memory.total,driver_version --format=csv,noheader")
   if (!r$success) {
     cat(sprintf("%s nvidia-smi -- GPU not detected or driver not installed\n", FAIL))
     return(FALSE)
@@ -88,11 +88,12 @@ check_gpu_info <- function() {
   cat(sprintf("%s GPU detected:\n", PASS))
   for (ln in strsplit(r$output, "\n", fixed = TRUE)[[1]]) {
     parts <- trimws(strsplit(ln, ",", fixed = TRUE)[[1]])
-    if (length(parts) < 3) next
-    name <- parts[1]; cc <- parts[2]; mem <- parts[3]
+    if (length(parts) < 4) next
+    name <- parts[1]; cc <- parts[2]; mem <- parts[3]; driver <- parts[4]
     cat(sprintf("       Name:             %s\n", name))
     cat(sprintf("       Compute Cap:      sm_%s\n", gsub(".", "", cc, fixed = TRUE)))
     cat(sprintf("       Memory:           %s\n", mem))
+    cat(sprintf("       Driver Version:   %s\n", driver))
     if (!grepl("3070", name, fixed = TRUE) && !grepl("86", cc, fixed = TRUE)) {
       cat(sprintf("  %s Expected RTX 3070 Ti (sm_86) -- got %s (sm_%s)\n",
                   INFO, name, gsub(".", "", cc, fixed = TRUE)))


### PR DESCRIPTION
## Summary

WS1 of the paper-grade documentation review (epic #110). Doc-correctness pass — no kernel source touched.

- `README.md:236` "CUDA 12.x" → "CUDA 13.2"; also fixed 2 prescriptive stale refs (`docs/tutorial/01-sass-hello-world.md`, `docs/tutorial/README.md`). Genuine historical refs in `docs/cuasm_r.md` and `docs/troubleshooting.md` left untouched.
- Consolidated toolchain-provenance footnote under "## Headline performance" in `README.md`, scoped to all 5 benchmark tables: RTX 3070 Ti (GA104, sm_86, 46-SM laptop bin), CUDA 13.2 / nvcc V13.2.78, driver 595.97.
- `scripts/verify_setup.R`: `nvidia-smi` query extended with `driver_version`; printed in the GPU Driver section.
- `Makefile`: new `figures` target (runs the 4 figure R scripts), added to the `reproduce` chain and `.PHONY`.

Closes #106.

## Note

Pushed with `--no-verify`: the pre-push hook's benchmark gate fails on a pre-existing `hgemm_16warp` 4096³ SwPowerCap thermal-throttle artifact (cold-clock measurement, no kernel code changed in this branch). Authorized by team lead for this docs-only branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)