### PR TITLE
feat: Hugging Face corpus publish tooling (WS4, #109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# bare-metal — local environment template
+#
+# Copy this file to .env and fill in real values. .env is gitignored and
+# must never be committed. Used by scripts/publish_hf.R (WS4, issue #109)
+# to publish the kernel corpus to the Hugging Face dataset repo.
+#
+#   cp .env.example .env
+#   # then edit .env and paste your token
+#
+# Hugging Face write-scoped access token.
+# Create one at: https://hf.co/settings/tokens  (role: Write)
+HF_TOKEN=hf_your_write_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ phase4/conv2d/debug_implicit2
 # Stray temp file from prior session (zero-byte tool error artifact)
 , None:0,parameters
 
+# Hugging Face publish artifact: SHA256SUMS is regenerated at upload
+# time by scripts/publish_hf.R; never committed (see WS4, issue #109).
+SHA256SUMS
+
 # Python
 __pycache__/
 *.pyc
@@ -55,6 +59,10 @@ tools/CuAssembler/
 
 # Claude Code / context
 .claude/
+
+# Secrets / local environment (never commit real tokens; .env.example is the tracked template)
+.env
+!.env.example
 
 # IDE / Editor
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,32 @@ The `.github/workflows/docs.yml` workflow covers only GPU-free checks: markdown
 link validation, version-string consistency, and Quarto doc rendering. Local
 `make reproduce` remains the only path for GPU verification.
 
+## Publishing the corpus to Hugging Face
+
+`make publish-hf` re-syncs the kernel corpus to the Hugging Face
+dataset repo `pjt222/ga104-cuda-kernels` (audience: SASS /
+optimization researchers). It is the single command behind WS4 of
+issue #109.
+
+The target runs `scripts/publish_hf.R`, which: verifies the toolchain
+and GPU, loads `HF_TOKEN`, rebuilds the corpus
+(`make clean && make all && make disasm` — **an Ampere GPU is
+required**), asserts every expected cubin/sass exists and is current
+and cross-checks coverage against `data/baselines.json`, writes
+`SHA256SUMS`, renders the dataset card from `hf/README.md`, and runs
+`hf repo create` + `hf upload`.
+
+`HF_TOKEN` (a write-scoped token) is read from the repo-root `.env`
+file, or from the environment if already set. Copy `.env.example` to
+`.env` and paste the token; `.env` is gitignored and must never be
+committed.
+
+Inspect the resolved upload manifest without building or uploading:
+
+```
+make publish-hf ARGS=--dry-run
+```
+
 ## R environment
 
 `renv.lock` pins R 4.6.0 and every script dependency. The

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ REFERENCE_BENCH    := $(shell find kernels/reference     -name 'bench*.cu' 2>/de
 # ------------------------------------------------------------------
 .PHONY: all cubins benches test clean disasm help \
         setup verify bench bench-reference compare-reference reference-pipeline reproduce figures \
+        publish-hf \
         tutorial gemm reductions attention convolution elementwise memory_layout composition reference
 
 all: cubins benches
@@ -177,6 +178,12 @@ compare-reference:
 
 reference-pipeline: reference bench-reference compare-reference
 
+# Publish the kernel corpus to the Hugging Face dataset repo
+# pjt222/ga104-cuda-kernels. Rebuilds the corpus first (GPU required)
+# and needs HF_TOKEN in .env. Dry-run: make publish-hf ARGS=--dry-run
+publish-hf:
+	@$(RSCRIPT) scripts/publish_hf.R $(ARGS)
+
 reproduce: setup verify all bench figures
 	@echo ""
 	@echo "================================================================"
@@ -216,6 +223,10 @@ help:
 	@echo "  make bench-reference — run local reference benches vs data/reference_baselines.json"
 	@echo "  make compare-reference — compare project baselines to local reference baselines"
 	@echo "  make reference-pipeline — build + validate + compare local reference benches"
+	@echo ""
+	@echo "Publish:"
+	@echo "  make publish-hf — rebuild + upload kernel corpus to the HF dataset repo"
+	@echo "  make publish-hf ARGS=--dry-run — resolve the upload manifest only (no build/upload)"
 	@echo ""
 	@echo "Build:"
 	@echo "  make all       — build all cubins + benches"

--- a/hf/README.md
+++ b/hf/README.md
@@ -1,0 +1,135 @@
+---
+license: mit
+language:
+  - en
+tags:
+  - cuda
+  - sass
+  - gpu-kernels
+  - ampere
+  - ga104
+  - sm_86
+  - optimization
+  - benchmarks
+pretty_name: GA104 Hand-Optimized CUDA Kernel Corpus
+configs:
+  - config_name: sass_histogram
+    data_files: data/sass_histogram.csv
+---
+
+# GA104 Hand-Optimized CUDA Kernel Corpus
+
+A measurement corpus of hand-optimized CUDA / SASS kernels targeting the
+**RTX 3070 Ti (GA104, sm_86, Ampere)**. Every kernel is written without
+cuBLAS, cuDNN, or PyTorch in the optimized path; vendor libraries are
+linked only for measured comparison under `kernels/reference/`. This
+dataset is for SASS and GPU-optimization researchers — it pairs each
+`.cu` source with its compiled machine code and its disassembly, so the
+exact instruction stream a kernel produced on this toolchain can be
+studied without owning the hardware.
+
+## The four laws of GA104
+
+The corpus is organized around four empirically derived constraints.
+The observations behind each are in `docs/gpu_reflections.md`.
+
+1. **Feed Tensor Cores continuously.** Overlap loads with HMMA / IMMA.
+   At ≥8 warps, `cp.async` benefit depends on the compute/load ratio —
+   helpful when compute is short, harmful when compute is long.
+2. **Read each byte of DRAM at most once per kernel.** im2col converts
+   9× re-reads to 1×; implicit GEMM eliminates the column buffer.
+3. **Fill the warp schedulers.** 32 warps/SM is ideal, 8 sufficient;
+   below 8 indicates a structural problem.
+4. **Never cross the 50 KB shared-memory cliff per block.** Blocks at
+   >50 KB drop to 1 block/SM (4 warps), a measured 2× regression.
+
+## sm_86 only
+
+Every artifact in this corpus is compiled for **compute capability 8.6
+(sm_86) only**. The cubins are not portable to other architectures and
+will not load on a non-Ampere or non-GA10x device. This is deliberate:
+the corpus is a single-target measurement record, not a portable
+kernel library. There are no fat binaries and no PTX-only fallbacks.
+
+## Provenance
+
+This corpus was built and published by `scripts/publish_hf.R` in the
+source repository. The stamp below is filled in at publish time.
+
+- **Source commit:** `{{COMMIT_SHA}}`
+- **Build date:** `{{BUILD_DATE}}`
+- **Compiler:** CUDA 13.2, `nvcc V13.2.78`
+- **Cubin build line:** `nvcc -arch=sm_86 -O2 --cubin`
+- **Disassembly:** `cuobjdump -sass` (via `scripts/build.R disasm`)
+- **Measurement hardware:** RTX 3070 Ti Laptop (GA104, 46-SM bin)
+
+## What the `.cubin` and `.sass` files are
+
+`*.sm_86.cubin` files are **GPU machine code** — ELF containers of
+sm_86 SASS, loaded through the CUDA Driver API (`cuModuleLoad`). They
+are *not* host executables; running one on a CPU does nothing. The
+matching `*.sm_86.sass` files are `cuobjdump -sass` disassembly of
+those cubins, provided so the instruction stream is greppable without
+a CUDA install.
+
+The repository's local R package `cuasmR` reads a cubin via
+`nvdisasm`, indexes instructions by `.text` byte offset, and patches at
+the byte level — a **byte-identical roundtrip** (`compile → disasm →
+reassemble`) is part of its test surface. See `docs/cuasm_r.md`.
+
+## Headline performance
+
+Measured on RTX 3070 Ti Laptop (GA104, sm_86, 46-SM bin), CUDA 13.2 /
+nvcc V13.2.78, driver 595.97. Sparse 2:4 figures are dense-equivalent
+(the multiply count the sparse pattern would do as dense work).
+
+| Kernel                   | Size             | GFLOPS / TOPS   | % peak |
+|--------------------------|------------------|-----------------|--------|
+| Sparse HGEMM 2:4         | 2048³            | **41,721** (eq) | 24.0%  |
+| Sparse INT8 mma.sp       | 2048³            | 39,674 (eq)     | 11.4%  |
+| HGEMM 16-warp            | 4096³            | 31,910          | 18.3%  |
+| IGEMM 128×256            | 4096³            | 27,591          | 7.9%   |
+| Flash Attention v2       | seq=1024 b=8 h=8 | 11,453          | 6.6%   |
+| Conv2d implicit GEMM     | 64×64, 320ch     | 6,687           | 3.8%   |
+
+The headline figure is **41,721 GFLOPS dense-equivalent** for sparse
+2:4 HGEMM at 2048³. Full per-kernel tables and the phase progression
+(naive SGEMM → sparse INT8, 90.5× cumulative) are in
+`docs/inventory.md`.
+
+## File layout
+
+The corpus distinguishes **tracked sources** from the **generated
+supplement** rebuilt at publish time.
+
+| Path             | Contents                                                       |
+|------------------|----------------------------------------------------------------|
+| `kernels/`       | Tracked `.cu` / `.cuh` kernel sources, grouped by family       |
+| `kernels/**/*_handtuned.sm_86.cubin` | Tracked hand-patched cubins (SASS hand-edits) |
+| `generated/`     | Rebuilt full `.sm_86.cubin` + `.sm_86.sass` set (build output) |
+| `data/`          | Regenerable CSV/JSON: baselines, register audit, SASS histogram|
+| `docs/`          | Researcher-facing analyses and references                      |
+| `AGENTS.md`      | Hardware constants, toolchain, conventions, the four laws      |
+| `SHA256SUMS`     | SHA-256 of every cubin in the corpus                           |
+| `LICENSE`        | MIT                                                            |
+
+`generated/` is build output — it is rebuilt deterministically from
+the tracked `kernels/` sources with the build line above. Treat
+`kernels/` as canonical and `generated/` as a convenience supplement.
+
+## Reproduction
+
+The single source of truth and the only supported reproduction path is
+the GitHub repository:
+
+**https://github.com/pjt222/bare-metal**
+
+From a fresh clone on an sm_86 host: `make reproduce` (setup → verify →
+build → bench). This dataset is a published snapshot; it is not the
+build system.
+
+## License
+
+MIT. See `LICENSE`. Vendor libraries linked under
+`kernels/reference/` for comparison are *not* redistributed here — only
+the project's own benchmark wrappers are included.

--- a/scripts/publish_hf.R
+++ b/scripts/publish_hf.R
@@ -1,0 +1,491 @@
+#!/usr/bin/env Rscript
+# publish_hf.R -- publish the GA104 kernel corpus to the Hugging Face
+# dataset repo pjt222/ga104-cuda-kernels (WS4, issue #109).
+#
+# Run from the repo root:
+#   Rscript scripts/publish_hf.R            # full build + upload
+#   Rscript scripts/publish_hf.R --dry-run  # resolve manifest only
+#
+# Stages (full run):
+#   1. verify    -- toolchain + GPU present (scripts/verify_setup.R)
+#   2. token     -- load HF_TOKEN from .env or the environment
+#   3. build     -- make clean && make all && make disasm
+#   4. manifest  -- assert every expected cubin/sass exists and is
+#                   current; cross-check coverage vs data/baselines.json
+#   5. checksums -- write SHA256SUMS over every cubin
+#   6. card      -- render hf/README.md into the staging dir
+#   7. upload    -- hf repo create + hf upload
+#
+# --dry-run prints the resolved manifest and the hf commands WITHOUT
+# building, cleaning, rendering, or uploading. It is safe on a tree
+# that has never been built.
+#
+# (uses base R only -- no library() loads needed)
+
+# --------------------------------------------------------------------
+# Repo root + WSL path/library fixups (mirrors scripts/verify_setup.R)
+# --------------------------------------------------------------------
+REPO_ROOT <- {
+  args_full <- commandArgs(trailingOnly = FALSE)
+  fa <- grep("^--file=", args_full, value = TRUE)
+  if (length(fa)) normalizePath(dirname(dirname(sub("^--file=", "", fa[1]))))
+  else            normalizePath(getwd())
+}
+
+CUDA_BIN <- "/usr/local/cuda/bin"
+if (dir.exists(CUDA_BIN) && !grepl(CUDA_BIN, Sys.getenv("PATH"), fixed = TRUE)) {
+  Sys.setenv(PATH = paste(CUDA_BIN, Sys.getenv("PATH"), sep = ":"))
+}
+WSL_CUDA_LIB <- "/usr/lib/wsl/lib"
+if (dir.exists(WSL_CUDA_LIB) &&
+    !grepl(WSL_CUDA_LIB, Sys.getenv("LD_LIBRARY_PATH"), fixed = TRUE)) {
+  cur <- Sys.getenv("LD_LIBRARY_PATH")
+  Sys.setenv(LD_LIBRARY_PATH = if (nzchar(cur)) paste(WSL_CUDA_LIB, cur, sep = ":") else WSL_CUDA_LIB)
+}
+
+PASS <- "\033[92m[PASS]\033[0m"
+FAIL <- "\033[91m[FAIL]\033[0m"
+INFO <- "\033[94m[INFO]\033[0m"
+
+DATASET_REPO <- "pjt222/ga104-cuda-kernels"
+
+# --------------------------------------------------------------------
+# Small helpers
+# --------------------------------------------------------------------
+die <- function(...) {
+  cat(sprintf("%s %s\n", FAIL, paste0(..., collapse = "")))
+  quit(status = 1L)
+}
+
+info <- function(...) cat(sprintf("%s %s\n", INFO, paste0(..., collapse = "")))
+ok   <- function(...) cat(sprintf("%s %s\n", PASS, paste0(..., collapse = "")))
+
+# Run a shell command, streaming output; stop the script on non-zero.
+run_or_die <- function(cmd, label) {
+  info(sprintf("%s: %s", label, cmd))
+  status <- system(cmd)
+  if (status != 0L) die(sprintf("%s failed (exit %d)", label, status))
+}
+
+# --------------------------------------------------------------------
+# Stage 2: load HF_TOKEN
+#
+# Resolution order: an HF_TOKEN already in the environment wins; the
+# repo-root .env is only a fallback. .env is parsed as KEY=VALUE lines
+# (blank lines and # comments skipped, surrounding quotes stripped).
+# --------------------------------------------------------------------
+load_hf_token <- function() {
+  token <- Sys.getenv("HF_TOKEN", unset = "")
+  if (nzchar(token)) {
+    info("HF_TOKEN found in the environment.")
+    return(token)
+  }
+  env_path <- file.path(REPO_ROOT, ".env")
+  if (file.exists(env_path)) {
+    for (line in readLines(env_path, warn = FALSE)) {
+      trimmed <- trimws(line)
+      if (!nzchar(trimmed) || startsWith(trimmed, "#")) next
+      eq <- regexpr("=", trimmed, fixed = TRUE)
+      if (eq < 1L) next
+      key <- trimws(substr(trimmed, 1L, eq - 1L))
+      val <- trimws(substr(trimmed, eq + 1L, nchar(trimmed)))
+      val <- gsub('^["\']|["\']$', "", val)
+      if (key == "HF_TOKEN" && nzchar(val)) {
+        info("HF_TOKEN loaded from .env")
+        return(val)
+      }
+    }
+  }
+  die("No HF_TOKEN found. Set it in the environment or copy .env.example ",
+      "to .env and paste a write-scoped token (see https://hf.co/settings/tokens).")
+}
+
+# --------------------------------------------------------------------
+# Manifest construction
+#
+# The manifest is the explicit set of paths uploaded to the dataset
+# repo, each as (src = path on disk, dest = path in the repo). Sources
+# keep their repo-relative path; the regenerated cubin/sass set is
+# placed under a generated/ prefix.
+# --------------------------------------------------------------------
+
+# Researcher-facing docs to publish (excludes CONTINUE_HERE.md and the
+# session-scoped / build-internal docs).
+DOC_FILES <- c(
+  "inventory.md", "comparison_to_sota.md", "gpu_reflections.md",
+  "index.md", "roofline_measured.md", "sass_histogram.md",
+  "register_audit.md", "ampere_sass_reference.md", "control_codes.md",
+  "memory_hierarchy.md", "cuasm_r.md"
+)
+
+# Tracked kernel sources: every .cu/.cuh under kernels/.
+kernel_sources <- function() {
+  list.files(file.path(REPO_ROOT, "kernels"),
+             pattern = "\\.(cu|cuh)$", recursive = TRUE, full.names = TRUE)
+}
+
+# Tracked hand-tuned cubins. Discovered by glob, not hardcoded -- the
+# .gitignore !*_handtuned.sm_86.cubin rule tracks any number of these.
+handtuned_cubins <- function() {
+  list.files(file.path(REPO_ROOT, "kernels"),
+             pattern = "_handtuned\\.sm_86\\.cubin$",
+             recursive = TRUE, full.names = TRUE)
+}
+
+# Regenerated full cubin/sass set produced by `make all && make disasm`.
+# Hand-tuned cubins are excluded here -- they ship under their tracked
+# kernels/ path (their canonical home), not the generated/ supplement.
+generated_artifacts <- function() {
+  cubins <- list.files(file.path(REPO_ROOT, "kernels"),
+                        pattern = "\\.sm_86\\.cubin$",
+                        recursive = TRUE, full.names = TRUE)
+  cubins <- cubins[!grepl("_handtuned\\.sm_86\\.cubin$", cubins)]
+  sass <- list.files(file.path(REPO_ROOT, "kernels"),
+                     pattern = "\\.sm_86\\.sass$",
+                     recursive = TRUE, full.names = TRUE)
+  c(cubins, sass)
+}
+
+# Tracked handtuned cubin paths, per git -- restored after `make clean`
+# wipes them (see restore_handtuned_cubins).
+tracked_handtuned <- function() {
+  out <- tryCatch(
+    system2("git", c("-C", shQuote(REPO_ROOT), "ls-files",
+                     "*_handtuned.sm_86.cubin"), stdout = TRUE),
+    error = function(e) character(0))
+  out <- out[nzchar(out)]
+  if (length(out)) file.path(REPO_ROOT, out) else character(0)
+}
+
+# `make clean` deletes every *.sm_86.cubin, including the hand-tuned
+# cubins -- and `make all` cannot regenerate them (they come from a
+# .cuasm hand-edit, not a .cu source). Restore them from git so the
+# corpus is complete.
+restore_handtuned_cubins <- function() {
+  tracked <- tracked_handtuned()
+  if (length(tracked) == 0L) {
+    info("no tracked hand-tuned cubins to restore.")
+    return(invisible())
+  }
+  rel <- vapply(tracked,
+                function(p) sub(paste0("^", REPO_ROOT, "/"), "", p),
+                character(1))
+  status <- system2("git", c("-C", shQuote(REPO_ROOT), "checkout",
+                              "HEAD", "--", shQuote(rel)))
+  if (status != 0L) die("failed to restore tracked hand-tuned cubins.")
+  missing <- tracked[!file.exists(tracked)]
+  if (length(missing)) {
+    die(sprintf("hand-tuned cubin missing after restore: %s",
+                paste(missing, collapse = ", ")))
+  }
+  ok(sprintf("restored %d tracked hand-tuned cubin(s) from git.",
+             length(tracked)))
+}
+
+# Build the (src, dest) manifest. Pure path arithmetic -- no file
+# existence required, so this is safe to call during --dry-run.
+build_manifest <- function() {
+  rel <- function(p) sub(paste0("^", REPO_ROOT, "/"), "", p)
+  m <- list()
+  add <- function(src, dest) m[[length(m) + 1L]] <<- list(src = src, dest = dest)
+
+  for (f in kernel_sources())   add(f, rel(f))
+  for (f in handtuned_cubins()) add(f, rel(f))
+  for (f in generated_artifacts()) add(f, file.path("generated", rel(f)))
+
+  add(file.path(REPO_ROOT, "data"), "data")            # whole dir
+
+  for (d in DOC_FILES) {
+    p <- file.path(REPO_ROOT, "docs", d)
+    add(p, file.path("docs", d))
+  }
+
+  add(file.path(REPO_ROOT, "AGENTS.md"),  "AGENTS.md")
+  add(file.path(REPO_ROOT, "LICENSE"),    "LICENSE")
+  add(file.path(REPO_ROOT, "SHA256SUMS"), "SHA256SUMS")
+
+  m
+}
+
+# --------------------------------------------------------------------
+# Stage 4: manifest assertion
+#
+# Every expected cubin/sass must exist and be newer than the .cu it
+# was compiled from; every kernel tracked in data/baselines.json must
+# have its cubin present. Any gap aborts -- a stale or near-empty
+# snapshot must never upload.
+# --------------------------------------------------------------------
+assert_corpus_current <- function() {
+  cubins <- list.files(file.path(REPO_ROOT, "kernels"),
+                        pattern = "\\.sm_86\\.cubin$",
+                        recursive = TRUE, full.names = TRUE)
+  if (length(cubins) == 0L) {
+    die("No .sm_86.cubin files under kernels/ -- the corpus did not build.")
+  }
+  # Hand-tuned cubins are checked separately below: they have no .cu
+  # source and `make disasm` produces no .sass for them, so the
+  # cu/sass currency checks below do not apply.
+  generated_cubins <- cubins[!grepl("_handtuned\\.sm_86\\.cubin$", cubins)]
+
+  problems <- character()
+
+  for (cubin in generated_cubins) {
+    cu <- sub("\\.sm_86\\.cubin$", ".cu", cubin)
+    sass <- sub("\\.cubin$", ".sass", cubin)
+    if (!file.exists(sass)) {
+      problems <- c(problems, sprintf("missing disassembly: %s", sass))
+      next
+    }
+    if (file.exists(cu) &&
+        file.info(cubin)$mtime < file.info(cu)$mtime) {
+      problems <- c(problems,
+                    sprintf("stale cubin (older than source): %s", cubin))
+    }
+    if (file.info(sass)$mtime < file.info(cubin)$mtime) {
+      problems <- c(problems,
+                    sprintf("stale disassembly (older than cubin): %s", sass))
+    }
+  }
+
+  # Coverage cross-check: every kernel keyed in baselines.json must
+  # have produced a cubin.
+  baselines_path <- file.path(REPO_ROOT, "data", "baselines.json")
+  if (!requireNamespace("jsonlite", quietly = TRUE)) {
+    die("package 'jsonlite' is required (run `make setup`).")
+  }
+  baselines <- jsonlite::fromJSON(baselines_path, simplifyVector = FALSE)
+  for (kernel_cu in names(baselines$kernels)) {
+    expected_cubin <- file.path(REPO_ROOT,
+                                sub("\\.cu$", ".sm_86.cubin", kernel_cu))
+    if (!file.exists(expected_cubin)) {
+      problems <- c(problems,
+                    sprintf("baselines.json kernel has no cubin: %s", kernel_cu))
+    }
+  }
+
+  # Every cubin git tracks as hand-tuned must be present -- `make clean`
+  # deletes them and `make all` cannot rebuild them.
+  for (ht in tracked_handtuned()) {
+    if (!file.exists(ht)) {
+      problems <- c(problems,
+                    sprintf("tracked hand-tuned cubin missing: %s", ht))
+    }
+  }
+
+  if (length(problems)) {
+    cat(sprintf("%s manifest assertion failed -- %d problem(s):\n",
+                FAIL, length(problems)))
+    for (p in problems) cat(sprintf("       - %s\n", p))
+    quit(status = 1L)
+  }
+  ok(sprintf("manifest assertion passed (%d cubins, all current, ",
+             length(cubins)),
+     sprintf("%d baselines.json kernels covered).",
+             length(baselines$kernels)))
+}
+
+# --------------------------------------------------------------------
+# Stage 5: SHA256SUMS over every cubin
+# --------------------------------------------------------------------
+write_sha256sums <- function() {
+  cubins <- c(
+    list.files(file.path(REPO_ROOT, "kernels"),
+               pattern = "\\.sm_86\\.cubin$",
+               recursive = TRUE, full.names = TRUE)
+  )
+  cubins <- sort(cubins)
+  rel <- function(p) sub(paste0("^", REPO_ROOT, "/"), "", p)
+  lines <- vapply(cubins, function(p) {
+    digest_out <- system2("sha256sum", shQuote(p), stdout = TRUE)
+    hex <- sub("\\s.*$", "", digest_out[1])
+    sprintf("%s  %s", hex, rel(p))
+  }, character(1))
+  out_path <- file.path(REPO_ROOT, "SHA256SUMS")
+  writeLines(lines, out_path)
+  ok(sprintf("wrote SHA256SUMS (%d cubins) -> %s", length(cubins), out_path))
+}
+
+# --------------------------------------------------------------------
+# Stage 6: render the dataset card
+# --------------------------------------------------------------------
+render_card <- function(staging_dir) {
+  template_path <- file.path(REPO_ROOT, "hf", "README.md")
+  if (!file.exists(template_path)) {
+    die("dataset card template not found at hf/README.md")
+  }
+  template <- paste(readLines(template_path, warn = FALSE), collapse = "\n")
+  commit <- tryCatch(
+    trimws(system2("git", c("-C", shQuote(REPO_ROOT), "rev-parse", "HEAD"),
+                    stdout = TRUE)),
+    error = function(e) "unknown")
+  build_date <- format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z")
+  rendered <- gsub("{{COMMIT_SHA}}", commit,     template, fixed = TRUE)
+  rendered <- gsub("{{BUILD_DATE}}", build_date, rendered, fixed = TRUE)
+  out_path <- file.path(staging_dir, "README.md")
+  writeLines(rendered, out_path)
+  ok(sprintf("rendered dataset card (commit %s, %s)",
+             substr(commit, 1, 12), build_date))
+}
+
+# --------------------------------------------------------------------
+# Stage 7 helpers: assemble the staging dir + the hf commands
+# --------------------------------------------------------------------
+hf_commands <- function(staging_dir) {
+  c(
+    sprintf("hf repo create datasets/%s --type dataset", DATASET_REPO),
+    sprintf("hf upload %s %s --repo-type dataset",
+            DATASET_REPO, shQuote(staging_dir))
+  )
+}
+
+stage_manifest <- function(manifest, staging_dir) {
+  for (entry in manifest) {
+    src <- entry$src
+    dest <- file.path(staging_dir, entry$dest)
+    if (!file.exists(src)) {
+      die(sprintf("manifest entry missing on disk: %s", src))
+    }
+    if (dir.exists(src)) {
+      dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+      file.copy(list.files(src, full.names = TRUE), dest,
+                recursive = TRUE)
+    } else {
+      dir.create(dirname(dest), recursive = TRUE, showWarnings = FALSE)
+      file.copy(src, dest, overwrite = TRUE)
+    }
+  }
+}
+
+# --------------------------------------------------------------------
+# Dry-run report
+# --------------------------------------------------------------------
+print_dry_run <- function(manifest) {
+  cat(strrep("=", 64), "\n")
+  cat("  publish_hf.R --dry-run -- no build, no render, no upload\n")
+  cat(strrep("=", 64), "\n\n")
+
+  rel <- function(p) sub(paste0("^", REPO_ROOT, "/"), "", p)
+  exists_count <- 0L
+  missing_count <- 0L
+
+  cat("Resolved upload manifest (src on disk -> dest in dataset repo):\n\n")
+  for (entry in manifest) {
+    present <- file.exists(entry$src)
+    if (present) exists_count <- exists_count + 1L
+    else         missing_count <- missing_count + 1L
+    tag <- if (present) "  ok " else "MISS "
+    cat(sprintf("  [%s] %-44s -> %s\n", tag, rel(entry$src), entry$dest))
+  }
+
+  ht <- handtuned_cubins()
+  gen <- generated_artifacts()
+  cat(sprintf("\n  hand-tuned cubins found: %d\n", length(ht)))
+  cat(sprintf("  generated cubin/sass artifacts on disk: %d\n", length(gen)))
+  cat(sprintf("  manifest entries: %d present, %d missing on disk\n",
+              exists_count, missing_count))
+  if (missing_count > 0L) {
+    cat(sprintf("\n  %s missing entries are expected on an unbuilt tree;\n",
+                INFO))
+    cat("        a full run regenerates them before the manifest assertion.\n")
+  }
+
+  cat("\nhf commands a full run would issue:\n\n")
+  for (cmd in hf_commands("<staging-dir>")) cat(sprintf("  %s\n", cmd))
+
+  cat(sprintf("\nDataset URL: https://huggingface.co/datasets/%s\n",
+              DATASET_REPO))
+  cat(strrep("=", 64), "\n")
+}
+
+# --------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------
+main <- function() {
+  argv <- commandArgs(trailingOnly = TRUE)
+  if (length(argv) && argv[1] %in% c("-h", "--help")) {
+    cat("Usage: publish_hf.R [--dry-run]\n")
+    cat("  (no args)   build the corpus and upload to Hugging Face\n")
+    cat("  --dry-run   print the resolved manifest + hf commands only\n")
+    quit(status = 0L)
+  }
+  dry_run <- "--dry-run" %in% argv
+
+  cat(strrep("=", 64), "\n")
+  cat("  bare-metal -- publish kernel corpus to Hugging Face\n")
+  cat(sprintf("  Target dataset: %s\n", DATASET_REPO))
+  cat(strrep("=", 64), "\n\n")
+
+  if (dry_run) {
+    # Dry-run: pure path arithmetic, no build, no token, no upload.
+    print_dry_run(build_manifest())
+    quit(status = 0L)
+  }
+
+  # --- Stage 1: verify toolchain + GPU -----------------------------
+  info("Stage 1/7: verifying toolchain + GPU ...")
+  verify_script <- file.path(REPO_ROOT, "scripts", "verify_setup.R")
+  status <- system2("Rscript", shQuote(verify_script))
+  if (status != 0L) die("environment verification failed (see above).")
+
+  # --- Stage 2: HF token -------------------------------------------
+  info("Stage 2/7: resolving HF_TOKEN ...")
+  token <- load_hf_token()
+  Sys.setenv(HF_TOKEN = token)
+
+  # --- Stage 3: materialize the corpus -----------------------------
+  info("Stage 3/7: rebuilding the corpus (make clean && make all && make disasm) ...")
+  run_or_die(sprintf("make -C %s clean",  shQuote(REPO_ROOT)), "make clean")
+  run_or_die(sprintf("make -C %s all",    shQuote(REPO_ROOT)), "make all")
+  run_or_die(sprintf("make -C %s disasm", shQuote(REPO_ROOT)), "make disasm")
+  # `make clean` also wiped the tracked hand-tuned cubins; restore them.
+  restore_handtuned_cubins()
+
+  # --- Stage 4: manifest assertion ---------------------------------
+  info("Stage 4/7: asserting the corpus is complete and current ...")
+  assert_corpus_current()
+
+  # --- Stage 5: checksums ------------------------------------------
+  info("Stage 5/7: writing SHA256SUMS ...")
+  write_sha256sums()
+
+  # --- Stage 6: stage files + render the card ----------------------
+  info("Stage 6/7: staging files + rendering the dataset card ...")
+  staging_dir <- tempfile("hf_publish_")
+  dir.create(staging_dir)
+  on.exit(unlink(staging_dir, recursive = TRUE), add = TRUE)
+  manifest <- build_manifest()
+  stage_manifest(manifest, staging_dir)
+  render_card(staging_dir)
+  ok(sprintf("staged %d manifest entries -> %s",
+             length(manifest), staging_dir))
+
+  # --- Stage 7: create the repo + upload ---------------------------
+  info("Stage 7/7: creating the dataset repo + uploading ...")
+  # hf repo create is idempotent: tolerate an existing repo.
+  create_cmd <- sprintf("hf repo create datasets/%s --type dataset 2>&1",
+                        DATASET_REPO)
+  create_out <- suppressWarnings(system(create_cmd, intern = TRUE))
+  if (!is.null(attr(create_out, "status")) &&
+      attr(create_out, "status") != 0L &&
+      !any(grepl("already (exists|created)|409", create_out,
+                 ignore.case = TRUE))) {
+    die(sprintf("hf repo create failed:\n%s",
+                paste(create_out, collapse = "\n")))
+  }
+  ok("dataset repo ready.")
+
+  run_or_die(sprintf("hf upload %s %s --repo-type dataset",
+                     DATASET_REPO, shQuote(staging_dir)),
+             "hf upload")
+
+  cat("\n")
+  ok("publish complete.")
+  cat(sprintf("  Dataset URL: https://huggingface.co/datasets/%s\n",
+              DATASET_REPO))
+  0L
+}
+
+if (sys.nframe() == 0L) {
+  rc <- main()
+  quit(status = if (is.null(rc)) 0L else rc)
+}


### PR DESCRIPTION
Closes #109

Adds the WS4 publish tooling for the GA104 kernel corpus to the
Hugging Face dataset repo `pjt222/ga104-cuda-kernels`. Tooling only —
the full build + upload (a ~1h GPU operation) is a separate user-run
step.

## Deliverables

- **`scripts/publish_hf.R`** — verify toolchain/GPU, load `HF_TOKEN`
  (env wins, `.env` fallback), rebuild the corpus
  (`make clean && make all && make disasm`), assert every cubin/sass
  is current and that `data/baselines.json` coverage is met, write
  `SHA256SUMS`, render the dataset card, `hf repo create` + `hf upload`.
  A `--dry-run` flag resolves the manifest and prints the `hf`
  commands without building, rendering, or uploading.
- **`hf/README.md`** — dataset card template (rendered at publish
  time, `{{COMMIT_SHA}}` / `{{BUILD_DATE}}` substituted). YAML
  frontmatter with a `sass_histogram` viewer config over
  `data/sass_histogram.csv`.
- **`Makefile`** — `publish-hf` target with `ARGS=` passthrough
  (`make publish-hf ARGS=--dry-run`), in `.PHONY` and help.
- **`AGENTS.md`** — documents the `make publish-hf` re-sync procedure.
- **`.gitignore` / `.env.example`** — `.env` (real token) and the
  generated `SHA256SUMS` ignored; `.env.example` is the template.

## Notes

- `make clean` deletes every `*.sm_86.cubin`, including the tracked
  hand-tuned cubin, which `make all` cannot rebuild (it comes from a
  `.cuasm` hand-edit). The script restores tracked
  `*_handtuned.sm_86.cubin` from git after the build and hard-asserts
  their presence before staging.
- The task brief expected 6 hand-tuned cubins; only 1 is tracked
  today (`kernels/gemm/igemm/igemm_tiled_handtuned.sm_86.cubin`). The
  script discovers them by glob, so it scales to however many exist.

## Validation

`Rscript scripts/publish_hf.R --dry-run` runs clean — no build, no
upload — and prints a 246-entry manifest (1 missing entry,
`SHA256SUMS`, expected on an unbuilt tree). The non-dry-run path was
not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)