### PR TITLE
fix(publish-hf): exclude test/probe and imma experiment artifacts

### DIFF
--- a/hf/README.md
+++ b/hf/README.md
@@ -106,7 +106,7 @@ supplement** rebuilt at publish time.
 |------------------|----------------------------------------------------------------|
 | `kernels/`       | Tracked `.cu` / `.cuh` kernel sources, grouped by family       |
 | `kernels/**/*_handtuned.sm_86.cubin` | Tracked hand-patched cubins (SASS hand-edits) |
-| `generated/`     | Rebuilt full `.sm_86.cubin` + `.sm_86.sass` set (build output) |
+| `generated/`     | Rebuilt `.sm_86.cubin` + `.sm_86.sass` set, build output (kernels of record only — test/probe binaries and negative-result experiment variants excluded) |
 | `data/`          | Regenerable CSV/JSON: baselines, register audit, SASS histogram|
 | `docs/`          | Researcher-facing analyses and references                      |
 | `AGENTS.md`      | Hardware constants, toolchain, conventions, the four laws      |

--- a/scripts/publish_hf.R
+++ b/scripts/publish_hf.R
@@ -132,9 +132,23 @@ handtuned_cubins <- function() {
              recursive = TRUE, full.names = TRUE)
 }
 
+# Build-output artifacts excluded from the published corpus -- they
+# are real output of tracked sources but are not kernels of record:
+#   - *.imma_s02/s04 cubins: negative-result hand-tune experiments
+#     (#96 sub-task A; also gitignored as such).
+#   - test_*/verify_* cubins/sass: correctness-test and layout-probe
+#     binaries, not kernels.
+# The matching .cu sources stay in the manifest (canonical source
+# tree); only their generated/ build artifacts are dropped.
+CORPUS_EXCLUDE <- c(
+  "\\.imma_s0[24]\\.sm_86\\.(cubin|sass)$",
+  "(^|/)(test|verify)_[^/]*\\.sm_86\\.(cubin|sass)$"
+)
+
 # Regenerated full cubin/sass set produced by `make all && make disasm`.
 # Hand-tuned cubins are excluded here -- they ship under their tracked
 # kernels/ path (their canonical home), not the generated/ supplement.
+# CORPUS_EXCLUDE artifacts are dropped from the published supplement.
 generated_artifacts <- function() {
   cubins <- list.files(file.path(REPO_ROOT, "kernels"),
                         pattern = "\\.sm_86\\.cubin$",
@@ -143,7 +157,9 @@ generated_artifacts <- function() {
   sass <- list.files(file.path(REPO_ROOT, "kernels"),
                      pattern = "\\.sm_86\\.sass$",
                      recursive = TRUE, full.names = TRUE)
-  c(cubins, sass)
+  arts <- c(cubins, sass)
+  for (pat in CORPUS_EXCLUDE) arts <- arts[!grepl(pat, arts)]
+  arts
 }
 
 # Tracked handtuned cubin paths, per git -- restored after `make clean`


### PR DESCRIPTION
Follow-up to #114. The `generated/` supplement globbed in build output that is not a kernel of record:

- igemm `*.imma_s02/s04` cubins — negative-result hand-tune experiments (#96 sub-task A; also gitignored as such)
- `test_*`/`verify_*` cubins — correctness tests and WMMA-layout probes

Adds `CORPUS_EXCLUDE` patterns to `scripts/publish_hf.R` so the published corpus is kernels-only. `.cu` sources are unaffected (they remain the canonical tracked tree). Dataset-card file-layout note updated to match.

Dry-run: generated artifacts 103 → 86, manifest 246 → 229 entries; no `imma`/`test_`/`verify_` cubins remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)