### PR TITLE
fix(build): add cross_attention to BENCH_VARIANT_DIRS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ kernels/tutorial/host: kernels/tutorial/host.cu
 # stem, so we generate one rule per directory via $(eval). To add a new
 # directory with bench variants, append it to BENCH_VARIANT_DIRS.
 BENCH_VARIANT_DIRS := \
+  kernels/attention/cross_attention \
   kernels/attention/flash_attention \
   kernels/convolution/conv2d \
   kernels/convolution/resblock \


### PR DESCRIPTION
`kernels/attention/cross_attention/` has `bench_pipelined.cu` and `bench_v2.cu`, but the directory was missing from `BENCH_VARIANT_DIRS`, so the Makefile's `$(eval)` loop generated no build rule for its `bench_*` variants — `make all` failed with `No rule to make target ... bench_pipelined`.

Masked until now: the `igemm_online_quant_bf_128x256` ptxas overflow (#117) aborted `make` before it reached the benches. With #117 fixed, this defect surfaced.

Verified: `make all` now completes **exit 0** repo-wide. Restores pipeline reproducibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)