### PR TITLE
perf(publish-hf): fast make sass target; add --skip-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ REFERENCE_BENCH    := $(shell find kernels/reference     -name 'bench*.cu' 2>/de
 # ------------------------------------------------------------------
 # Default target
 # ------------------------------------------------------------------
-.PHONY: all cubins benches test clean disasm help \
+.PHONY: all cubins benches test clean disasm sass help \
         setup verify bench bench-reference compare-reference reference-pipeline reproduce figures \
         publish-hf \
         tutorial gemm reductions attention convolution elementwise memory_layout composition reference
@@ -144,6 +144,21 @@ disasm: cubins
 		fi; \
 	done
 	@echo "=== Disassembly complete ==="
+
+# Fast SASS dump: cuobjdump -sass per cubin, no R/cuasmR/renv overhead.
+# `make disasm` spawns an R process per cubin (renv activation ~15s
+# each) to also produce the .cuasm hand-edit format; `make sass` skips
+# all that and only writes the raw .sass. Used by scripts/publish_hf.R.
+# For the .cuasm hand-edit workflow, use `make disasm` or
+# `Rscript scripts/build.R disasm <cubin>` directly.
+sass: cubins
+	@echo "=== Dumping SASS (cuobjdump) ==="
+	@for cubin in $(KERNEL_CUBINS); do \
+		if [ -f "$$cubin" ]; then \
+			cuobjdump -sass "$$cubin" > "$${cubin%.cubin}.sass" 2>/dev/null || true; \
+		fi; \
+	done
+	@echo "=== SASS dump complete ==="
 
 # ------------------------------------------------------------------
 # Reproducibility entry points.

--- a/scripts/publish_hf.R
+++ b/scripts/publish_hf.R
@@ -9,7 +9,7 @@
 # Stages (full run):
 #   1. verify    -- toolchain + GPU present (scripts/verify_setup.R)
 #   2. token     -- load HF_TOKEN from .env or the environment
-#   3. build     -- make clean && make all && make disasm
+#   3. build     -- make clean && make all && make sass
 #   4. manifest  -- assert every expected cubin/sass exists and is
 #                   current; cross-check coverage vs data/baselines.json
 #   5. checksums -- write SHA256SUMS over every cubin
@@ -419,12 +419,14 @@ print_dry_run <- function(manifest) {
 main <- function() {
   argv <- commandArgs(trailingOnly = TRUE)
   if (length(argv) && argv[1] %in% c("-h", "--help")) {
-    cat("Usage: publish_hf.R [--dry-run]\n")
-    cat("  (no args)   build the corpus and upload to Hugging Face\n")
-    cat("  --dry-run   print the resolved manifest + hf commands only\n")
+    cat("Usage: publish_hf.R [--dry-run] [--skip-build]\n")
+    cat("  (no args)    build the corpus and upload to Hugging Face\n")
+    cat("  --dry-run    print the resolved manifest + hf commands only\n")
+    cat("  --skip-build trust on-disk cubins; refresh SASS + upload only\n")
     quit(status = 0L)
   }
-  dry_run <- "--dry-run" %in% argv
+  dry_run    <- "--dry-run"    %in% argv
+  skip_build <- "--skip-build" %in% argv
 
   cat(strrep("=", 64), "\n")
   cat("  bare-metal -- publish kernel corpus to Hugging Face\n")
@@ -449,10 +451,18 @@ main <- function() {
   Sys.setenv(HF_TOKEN = token)
 
   # --- Stage 3: materialize the corpus -----------------------------
-  info("Stage 3/7: rebuilding the corpus (make clean && make all && make disasm) ...")
-  run_or_die(sprintf("make -C %s clean",  shQuote(REPO_ROOT)), "make clean")
-  run_or_die(sprintf("make -C %s all",    shQuote(REPO_ROOT)), "make all")
-  run_or_die(sprintf("make -C %s disasm", shQuote(REPO_ROOT)), "make disasm")
+  # `make sass` (fast cuobjdump dump) is used instead of `make disasm`
+  # (which spawns an R process per cubin) -- the corpus needs the raw
+  # .sass, not the .cuasm hand-edit format.
+  if (skip_build) {
+    info("Stage 3/7: --skip-build -- trusting on-disk cubins, refreshing SASS ...")
+    run_or_die(sprintf("make -C %s sass", shQuote(REPO_ROOT)), "make sass")
+  } else {
+    info("Stage 3/7: rebuilding the corpus (make clean && make all && make sass) ...")
+    run_or_die(sprintf("make -C %s clean", shQuote(REPO_ROOT)), "make clean")
+    run_or_die(sprintf("make -C %s all",   shQuote(REPO_ROOT)), "make all")
+    run_or_die(sprintf("make -C %s sass",  shQuote(REPO_ROOT)), "make sass")
+  }
   # `make clean` also wiped the tracked hand-tuned cubins; restore them.
   restore_handtuned_cubins()
 


### PR DESCRIPTION
The WS4 publish's disasm phase took ~an hour: `make disasm` spawns an R process per cubin to also produce the `.cuasm` hand-edit format, and each R startup pays ~15s of renv activation. The corpus only needs the raw `.sass`.

- **`make sass`** — new target: `cuobjdump -sass` per cubin, no R/renv. Whole corpus in **~60s** (measured) vs ~1h.
- **`publish_hf.R`** Stage 3 uses `make sass` instead of `make disasm`.
- **`--skip-build`** — new flag: trust on-disk cubins, refresh SASS + upload only, so a late-stage retry doesn't redo the ~20min `make all`.

`make disasm` is unchanged — still available for the `.cuasm` hand-edit workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)