### PR TITLE
#138: consolidate comparison-harness runners onto cuasmR (revive bench_flash_all)

### DIFF
--- a/scripts/bench/bench_flash_all.R
+++ b/scripts/bench/bench_flash_all.R
@@ -10,7 +10,7 @@
 #   Rscript scripts/bench/bench_flash_all.R 1024 8 8
 #   Rscript scripts/bench/bench_flash_all.R --build 1024 8 8
 
-# (uses base R only — no library() loads needed)
+suppressMessages(library(cuasmR))   # run_bench + parse_throughput (issue #138)
 
 # WSL CUDA libpath fix.
 .WSL_CUDA_LIB <- "/usr/lib/wsl/lib"
@@ -23,12 +23,24 @@ if (dir.exists(.WSL_CUDA_LIB) &&
 }
 
 REPO_ROOT <- {
+  # Walk up from the script dir to the repo marker -- matches the proven
+  # derivation in bench_regress.R (the old fixed dirname() count broke when
+  # the script moved to scripts/bench/, issue #138).
   args_full <- commandArgs(trailingOnly = FALSE)
   fa <- grep("^--file=", args_full, value = TRUE)
-  if (length(fa)) normalizePath(dirname(dirname(sub("^--file=", "", fa[1]))))
-  else            normalizePath(getwd())
+  start <- if (length(fa)) normalizePath(dirname(sub("^--file=", "", fa[1])))
+           else            normalizePath(getwd())
+  cur <- start
+  repeat {
+    if (file.exists(file.path(cur, ".git")) ||
+        file.exists(file.path(cur, "renv.lock"))) break
+    parent <- dirname(cur)
+    if (parent == cur) { cur <- start; break }  # marker never found
+    cur <- parent
+  }
+  cur
 }
-FLASH_DIR <- file.path(REPO_ROOT, "phase3", "flash_attention")
+FLASH_DIR <- file.path(REPO_ROOT, "kernels", "attention", "flash_attention")
 
 discover_benches <- function() {
   files <- list.files(FLASH_DIR, full.names = TRUE)
@@ -45,25 +57,20 @@ discover_benches <- function() {
 }
 
 run_bench <- function(exe_path, args) {
-  out <- tryCatch(
-    suppressWarnings(system2(exe_path, args, stdout = TRUE, stderr = TRUE,
-                             timeout = 120)),
-    error = function(e) {
-      attr(character(0), "status") <- 1L
-      character(0)
-    }
-  )
-  status <- attr(out, "status")
-  rc <- if (is.null(status)) 0L else as.integer(status)
-  output <- paste(out, collapse = "\n")
+  # Run + parse via cuasmR (issue #138). cuasmR::run_bench captures GPU state
+  # around the launch and returns a status-bearing rc with the correct
+  # can't-launch handler (the old inline `attr(character(0),"status")<-1L`
+  # threw and aborted the harness). parse_throughput replaces the inline
+  # ms/GFLOPS regex; pick = "first" matches the original, which took the first
+  # same-line "X ms ... Y GFLOPS" match (perl `.` does not cross newlines).
+  r <- cuasmR::run_bench(exe_path, args, timeout = 120)
+  output <- paste(r$out, collapse = "\n")
 
-  m <- list(raw = output, returncode = rc)
-  hit <- regmatches(output,
-                    regexec("([0-9.]+)\\s*ms.*?([0-9][0-9,.]*)\\s*GFLOPS",
-                            output, perl = TRUE, ignore.case = TRUE))[[1]]
-  if (length(hit) >= 3) {
-    m$ms     <- as.numeric(hit[2])
-    m$gflops <- as.numeric(gsub(",", "", hit[3], fixed = TRUE))
+  m <- list(raw = output, returncode = r$rc)
+  p <- cuasmR::parse_throughput(r$out, pick = "first")
+  if (!is.na(p$ms) && !is.na(p$throughput)) {
+    m$ms     <- p$ms
+    m$gflops <- p$throughput
   }
   m$check <- if (grepl("PASS", output, fixed = TRUE)) "PASS"
              else if (grepl("FAIL", output, fixed = TRUE)) "FAIL"
@@ -118,11 +125,11 @@ main <- function() {
     cat("No bench executables found in kernels/attention/flash_attention/\n")
     if (do_build) {
       cat("Attempting to build...\n")
-      system2("make", c("-C", dirname(FLASH_DIR), "phase3"))
+      system2("make", c("-C", REPO_ROOT, "attention"))
       benches <- discover_benches()
     }
     if (!length(benches)) {
-      cat("Run: make phase3\n"); quit(status = 1)
+      cat("Run: make attention\n"); quit(status = 1)
     }
   }
 

--- a/scripts/bench/bench_imma_s02.R
+++ b/scripts/bench/bench_imma_s02.R
@@ -47,6 +47,13 @@ cases <- list(
          line  = "igemm_tiled \\(64x64\\)")
 )
 
+# run_bench_grep -- intentionally NOT migrated to cuasmR (issue #138). A distinct
+# A/B grep-extract shape, not the statistical measurement primitive #134 packaged:
+# it greps a *regex* kernel label, extracts throughput only (no ms, no GPU-state
+# capture), for cubin-swap patch validation. cuasmR::parse_throughput uses
+# fixed-substring matching + ms+throughput, so routing this through it would be a
+# semantic regex->fixed change for no correctness gain on a non-gated tool. Kept
+# by design (byte-identical helper in bench_imma_s04.R).
 run_bench_grep <- function(grep_re) {
     # bench loads cubins relative to its CWD; run inside kernels/gemm/igemm.
     orig_cwd <- getwd()

--- a/scripts/bench/bench_imma_s04.R
+++ b/scripts/bench/bench_imma_s04.R
@@ -47,6 +47,13 @@ cases <- list(
          line  = "igemm_tiled \\(64x64\\)")
 )
 
+# run_bench_grep -- intentionally NOT migrated to cuasmR (issue #138). A distinct
+# A/B grep-extract shape, not the statistical measurement primitive #134 packaged:
+# it greps a *regex* kernel label, extracts throughput only (no ms, no GPU-state
+# capture), for cubin-swap patch validation. cuasmR::parse_throughput uses
+# fixed-substring matching + ms+throughput, so routing this through it would be a
+# semantic regex->fixed change for no correctness gain on a non-gated tool. Kept
+# by design (byte-identical helper in bench_imma_s02.R).
 run_bench_grep <- function(grep_re) {
     # bench loads cubins relative to its CWD; run inside kernels/gemm/igemm.
     orig_cwd <- getwd()


### PR DESCRIPTION
## Summary

Follow-up to #134, closing #138. Consolidates the A/B **comparison-harness**
run-and-parse runners that #134 left out of scope (it migrated the statistical
*regression* primitive). Also revives `bench_flash_all.R`, which has been dead at
the discovery level since the `phaseN/` → family-directory reorg.

## Changes

### `bench_flash_all.R` — rewire + revive
- **Rewire**: `run_bench` now calls `cuasmR::run_bench` + `parse_throughput(pick =
  "first")`. Removes the duplicated run-and-parse primitive **and** the
  can't-launch crash handler — the old `attr(character(0), "status") <- 1L` is not
  a valid assignment target; it *throws* `target of assignment expands to
  non-language object`, and inside the `tryCatch` error handler that propagates
  and aborts the whole harness (it never silently read rc=0). `cuasmR::run_bench`
  carries the correct `structure(character(0), status = 1L)` handler.
- **Revive** (the tool found 0 benches before this PR):
  - `FLASH_DIR`: stale `phase3/flash_attention` → `kernels/attention/flash_attention`.
  - `REPO_ROOT`: the fixed `dirname()` count resolved to `<repo>/scripts` after the
    script moved to `scripts/bench/`. Replaced with the marker-search (walk up to
    `.git`/`renv.lock`) used by `bench_regress.R`.
  - `--build` branch: `make phase3` → `make attention`.

### `bench_imma_s02.R` / `bench_imma_s04.R` — document, don't rewire
`run_bench_grep` is a genuinely distinct shape — it greps a **regex** kernel label
and extracts **throughput only** (no ms, no GPU-state capture), for cubin-swap
patch validation. Routing it through `cuasmR::parse_throughput`'s fixed-substring
matcher would be a semantic regex→fixed change for no correctness gain on a
non-gated tool. Documented as an accepted distinct shape (byte-identical helper in
both files).

## Verification — GPU-free

The pre-push gate (`make test` smoke + `bench_regress`) does **not** execute
`bench_flash_all` or the imma tools, so gate-green cannot validate this. Validated
without the GPU instead:

- **REPO_ROOT** marker-search resolves `scripts/bench` → repo root.
- **Discovery**: `discover_benches()` finds **14** flash benches at the revived path.
- **Behavior preservation**: fixture differential — the old inline
  `([0-9.]+)\s*ms.*?([0-9][0-9,.]*)\s*GFLOPS` regex vs the new
  `parse_throughput(pick = "first")` on `flash_br16_1024.txt` → **identical**
  `ms = 3.002 / gflops = 5834 / check = PASS`. (`perl` `.` does not cross newlines,
  so the old whole-output regex was already same-line; `pick = "first"` matches.)

## Scope
`run_bench`'s `returncode` is not branched on (quit status is the FAIL count), and
FA benches emit GFLOPS not TOPS, so the rc and unit-broadening differences in
`cuasmR::run_bench`/`parse_throughput` are inert here. No package code changed.

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
