### PR TITLE
docs: housekeeping audit pass — fix drift across 21 files (+ flag #140/#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ historical reference.
 ## Unreleased
 
 ### Changed
+- **cuasmR measurement-API migration (#134, cuasmR 0.1.0 → 0.2.0).** The
+  benchmark run → parse → validate → regress logic was migrated out of the
+  `scripts/{bench,probe}` harnesses into the `cuasmR` package as 12 new exports
+  (`run_bench`, `parse_throughput`, `validate_sample`, `collect_valid_samples`,
+  `report_median_metrics`, `check_regression`, `append_jsonl_row`, `read_jsonl`,
+  `capture_gpu_state`, `classify_meta`, `decode_throttle`, `summarise_meta`).
+  Seven harness scripts now `library(cuasmR)`; the package gained roxygen
+  `man/`, declared `Imports`, and a clean `R CMD check --as-cran` (0/0/1 on
+  Linux R 4.6.0). Landed as stacked PRs #136 + #137.
+- **bench_flash_all revival (#138, PR #139).** `bench_flash_all.R` rewired onto
+  `cuasmR::run_bench` + `parse_throughput` (removing a duplicated run-and-parse
+  primitive and a can't-launch crash handler) and revived: its dead
+  `phase3/flash_attention` discovery path → `kernels/attention/flash_attention`,
+  `REPO_ROOT` derivation fixed to a `.git`/`renv.lock` marker-search, and the
+  `--build` target `make phase3` → `make attention`. The `bench_imma_s02/s04.R`
+  `run_bench_grep` grep-extract helper was documented as an intentionally
+  distinct shape (not migrated).
 - Documentation review pass. Voice and provenance leakage cleaned
   up across user-facing docs; "Tier N" jargon retained only in
   this file. Created `AGENTS.md` as the canonical agent-facing

--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ make reproduce          # setup + verify + build + bench-vs-baselines
 ```
 
 `make reproduce` chains `setup` (renv restore + cuasmR install),
-`verify` (env check), `all` (compile every cubin + bench), and
-`bench` (run benches and compare against `data/baselines.json`).
-A clean run ends with `RESULT: PASSED -- all benchmarks within
-tolerance`. The pre-push hook calls the same regression check. Build
-entry points are documented in [`AGENTS.md`](AGENTS.md).
+`verify` (env check), `all` (compile every cubin + bench), `bench`
+(run benches and compare against `data/baselines.json`; this stage
+prints `RESULT: PASSED -- all benchmarks within tolerance`), and
+`figures` (regenerate `docs/figures/`). The run finishes with the
+`Full reproduction complete` banner. The pre-push hook calls the same
+regression check. Build entry points are documented in
+[`AGENTS.md`](AGENTS.md).
 
 ## License
 

--- a/docs/CONTINUE_HERE.md
+++ b/docs/CONTINUE_HERE.md
@@ -1,6 +1,6 @@
 # Session handoff
 
-> Last updated: 2026-06-03 (#134 CLOSED — PR-A #136 `ea0e7e6` + PR-B #137 `4ed0e55` both MERGED to main via merge-commits; cuasmR 0.2.0 on main, R CMD check 0/0/1 canonical Linux R. Adversarial review: 0 blockers/0 majors. Follow-up #138 filed (comparison-harness consolidation). Next = #135 Ctrl+C re-test / #124 bench-all. Use WSL Linux R for R work, not Windows Rscript.exe) | Branch: main
+> Last updated: 2026-06-03 (#134 CLOSED — PR-A #136 `ea0e7e6` + PR-B #137 `4ed0e55` both MERGED; cuasmR 0.2.0 on main, R CMD check 0/0/1 canonical Linux R. Adversarial review: 0 blockers/0 majors. Follow-up #138 CLOSED — merged via PR #139 `f4160cb` (bench_flash_all rewired onto cuasmR + revived; imma s02/s04 left distinct). Docs-housekeeping audit pass done. Next = #135 (grid-sweep Ctrl+C re-test) / #124 (bench-all). Use WSL Linux R for R work, not Windows Rscript.exe) | Branch: main
 
 Per-author scratchpad for picking up where the previous working
 session left off. Expected to churn between sessions. Durable
@@ -54,7 +54,11 @@ are benchmark-pipeline hardening — no queued kernel work.
 | 124 | `bench-all` one-click full-corpus benchmark runner (epic)      |
 | 128 | Overclocked single-kernel showcase mode (deferred)             |
 | 135 | Multi-kernel × clock grid sweep tool (filed 2026-05-27)        |
-| 138 | Consolidate comparison-harness runners onto cuasmR (filed 2026-06-03, low-pri; bench_flash_all + bench_imma_s02/s04 + latent crash twin) |
+
+Resolved 2026-06-03: **#138** via PR #139 (`f4160cb`) — bench_flash_all.R
+rewired onto `cuasmR::run_bench` + `parse_throughput` and revived (dead
+`phase3/` path → `kernels/attention/flash_attention`); bench_imma_s02/s04
+grep-extract shape left intentionally distinct.
 
 Resolved 2026-05-27: **#131** (lock-aware bench_regress — Phase 1
 end-to-end verified, `ecae5b7` + `7bfc307` pushed) and **#125**

--- a/docs/CONTINUE_HERE.md
+++ b/docs/CONTINUE_HERE.md
@@ -1,6 +1,54 @@
 # Session handoff
 
-> Last updated: 2026-06-03 (#134 CLOSED — PR-A #136 `ea0e7e6` + PR-B #137 `4ed0e55` both MERGED; cuasmR 0.2.0 on main, R CMD check 0/0/1 canonical Linux R. Adversarial review: 0 blockers/0 majors. Follow-up #138 CLOSED — merged via PR #139 `f4160cb` (bench_flash_all rewired onto cuasmR + revived; imma s02/s04 left distinct). Docs-housekeeping audit pass done. Next = #135 (grid-sweep Ctrl+C re-test) / #124 (bench-all). Use WSL Linux R for R work, not Windows Rscript.exe) | Branch: main
+> Last updated: 2026-06-03T13:35Z (#134 epic + #138 both CLOSED/merged; cuasmR
+> 0.2.0 on main. Docs housekeeping = **PR #142 OPEN** (awaiting merge). #140/#141
+> filed for measurement. Use WSL Linux R, not Windows Rscript.exe) | Branch of
+> open work: `docs/housekeeping-audit-2026-06-03` (→ main on #142 merge)
+
+## ▶ SESSION END — 2026-06-03 (docs housekeeping + #134 lineage drain)
+
+**Objective.** Drain the #134 (cuasmR CRAN-ready) epic lineage and bring all
+documentation current.
+
+**Completed (merged unless noted):**
+- **#134 epic CLOSED** — PR #136 (`ea0e7e6`) + PR #137 (`4ed0e55`) merged: cuasmR
+  0.1.0→0.2.0 measurement API migration. Adversarial review 0 blockers/0 majors.
+- **#138 CLOSED** — PR #139 (`f4160cb`) merged: `bench_flash_all.R` rewired onto
+  `cuasmR::run_bench` + revived; imma s02/s04 grep-shape left distinct.
+- **Docs housekeeping → PR #142 OPEN** (`b07567c`, 21 files): multi-agent drift
+  audit (40 confirmed) + fixes. Pre-push gate green.
+- GitHub repo description + topics updated (cuasmR surfaced; +rstats/+r-package).
+
+**In Progress / awaiting:**
+- **PR #142 OPEN, NOT merged.** base main, MERGEABLE, `closingIssuesReferences:[]`,
+  CI green at push. Next = watch CI + merge (merge-commit; nothing stacked on it).
+  It edits THIS file — do **not** edit `docs/CONTINUE_HERE.md` on main while #142
+  is open (stacked-file 3-way conflict; see `project_stacked_pr_merge_mechanics`).
+
+**Next steps:**
+1. Merge **#142** once CI green.
+2. **[USER / measurement]** **#140** — re-measure Sparse HGEMM 2:4 (2048³ + 4096³)
+   to resolve the `41,721` vs `31.9 TFLOPS` value + the 2048³/4096³ size conflict;
+   reconcile `inventory.md`, `gpu_reflections.md`, `hgemm_sparse/README`, GitHub
+   desc. Inline `⚠ #140` flags already placed.
+3. **[USER decision]** **#141** — INT8 IMMA peak convention: `348` (dense) vs `696`
+   (2:4 sparse) across `kernel_architecture.qmd` + the `igemm` bench `.cu`. Inline
+   `⚠ #141` flag placed.
+4. **#135** (grid-sweep Ctrl+C single-press re-test, elevated pwsh — see step
+   detail below) / **#124** (bench-all one-click runner, builds on cuasmR API).
+
+**Context / decisions (negative space):**
+- **Numbers trap held:** did NOT auto-fix #140/#141 — no measurement file
+  arbitrates the values; flagged + filed rather than invent. Adversarial verify
+  caught a real numbers-trap walk (gpu_reflections size mis-pairing).
+- **Gate coverage:** pre-push gate + docs CI run only `make test` smoke +
+  `bench_regress` + link/version/quarto — NOT bench_flash_all / imma / grid / doc
+  tools. Verify those GPU-free (fixture diff, link-check). See
+  `project_gate_coverage_gpu_free_verify`.
+- **Subagent output ≠ ground truth:** audit recommendations had ≥2 errors
+  (hgemm path depth, a numbers-trap value); re-derive from primary source.
+
+---
 
 Per-author scratchpad for picking up where the previous working
 session left off. Expected to churn between sessions. Durable
@@ -54,6 +102,8 @@ are benchmark-pipeline hardening — no queued kernel work.
 | 124 | `bench-all` one-click full-corpus benchmark runner (epic)      |
 | 128 | Overclocked single-kernel showcase mode (deferred)             |
 | 135 | Multi-kernel × clock grid sweep tool (filed 2026-05-27)        |
+| 140 | Reconcile Sparse HGEMM 2:4 headline number (value + size) — needs measurement (filed 2026-06-03) |
+| 141 | Standardize INT8 IMMA peak: 348 dense vs 696 sparse across docs + igemm bench (filed 2026-06-03) |
 
 Resolved 2026-06-03: **#138** via PR #139 (`f4160cb`) — bench_flash_all.R
 rewired onto `cuasmR::run_bench` + `parse_throughput` and revived (dead

--- a/docs/analysis/kernel_architecture.qmd
+++ b/docs/analysis/kernel_architecture.qmd
@@ -61,7 +61,7 @@ performance on GA104: **registers**, **shared memory**, and **warp occupancy**.
 
 | Resource | GA104 (RTX 3070 Ti Laptop) |
 |---|---|
-| Streaming Multiprocessors | 48 |
+| Streaming Multiprocessors | 46 |
 | CUDA cores / SM | 128 |
 | Tensor Cores / SM | 4 (3rd gen) |
 | Registers / SM | 65,536 (32-bit) |
@@ -71,6 +71,12 @@ performance on GA104: **registers**, **shared memory**, and **warp occupancy**.
 | FP32 peak (FFMA) | 21.7 TFLOPS |
 | FP16 Tensor peak (HMMA) | 174 TFLOPS |
 | INT8 Tensor peak (IMMA) | 696 TOPS |
+
+> **⚠ INT8 IMMA peak convention under review ([#141](https://github.com/pjt222/bare-metal/issues/141)).**
+> 696 TOPS is the 2:4-sparse-doubled figure; the *dense* INT8 IMMA peak is
+> 348 TOPS (per `AGENTS.md` / `docs/inventory.md`). The %-of-INT8-peak figures
+> in this document use the 696,000 denominator; #141 will standardize on one
+> convention across the docs and the `igemm` bench.
 
 ## The Occupancy Model {#sec-occupancy}
 
@@ -610,8 +616,8 @@ The three highest-impact optimizations, in recommended order:
 3. **LDSM-interleaved inner loops** (+5--15%): manual scheduling of smem loads
    between HMMA pairs for near-maximum TC pipeline utilization. (Issue #19)
 
-**Update (post-optimization sprint):** Steps 1-2 alone achieved **32,197 GFLOPS
-(18.5% of FP16 peak)** --- far exceeding the predicted ~25 TFLOPS ceiling.
+**Update (post-optimization sprint):** Steps 1-2 alone achieved **31,910 GFLOPS
+(18.3% of FP16 peak)** --- far exceeding the predicted ~25 TFLOPS ceiling.
 Bank-conflict padding (+39%) and 16-byte cp.async (+39%) compound dramatically.
 Step 3 (256x128 tile) was a negative result (-38%: occupancy loss outweighs
 higher AI). Steps 4-5 (triple-buffer, LDSM interleaving) are infeasible or

--- a/docs/benchmark_methodology.md
+++ b/docs/benchmark_methodology.md
@@ -18,14 +18,14 @@ not comparable to each other or to a baseline recorded earlier.
 
 `scripts/bench/bench_regress.R` already refuses to compare a run
 against a baseline when the GPU was throttled during the run (see
-`bench_meta.R::classify_meta`). That keeps the regression gate
+`cuasmR::classify_meta`). That keeps the regression gate
 honest, but it means a throttled run is *skipped* — and a full
 "run everything" pass needs a way to not silently drop runs.
 
 ## Throttle taxonomy
 
 `nvidia-smi` reports an active-throttle bitmask, decoded in
-`bench_meta.R::decode_throttle`. The states that make a measurement
+`cuasmR::decode_throttle`. The states that make a measurement
 unfair (`.UNFAIR_THROTTLES`):
 
 | Reason | Meaning |
@@ -189,7 +189,8 @@ run:
 export BARE_METAL_GPU_MODE=dgpu     # or: hybrid
 ```
 
-`scripts/bench/bench_meta.R` (`capture_gpu_state()`) records it as
+`cuasmR::capture_gpu_state()` (the `scripts/bench/bench_meta.R` path is now a
+thin `library(cuasmR)` shim) records it as
 `$host$gpu_mode` in every run's metadata, and the one-line GPU-state
 header printed by `bench_regress.R` shows `gpu_mode=...`. Accepted
 values are `hybrid` and `dgpu`; anything else, including unset,

--- a/docs/cuasm_r.md
+++ b/docs/cuasm_r.md
@@ -1,5 +1,11 @@
 # cuasmR — R-native SASS hand-edit toolchain
 
+Documents **cuasmR 0.2.0**. The package now has two surfaces: the SASS cubin
+read / write / patch toolchain (most of this document) and the **benchmark
+measurement API** added in 0.2.0 ([#134](https://github.com/pjt222/bare-metal/issues/134))
+— see the *Measurement API* section below. 20 exported functions total
+(8 cubin + 12 measurement).
+
 Replaces the upstream Python [`cloudcores/CuAssembler`](https://github.com/cloudcores/CuAssembler) for the `.cubin → edit → .cubin` workflow on this project (#102).
 
 **Why custom**: upstream is ~2 years stale and breaks on every CUDA major-version bump. CUDA 13.2 changed the cubin `e_flags` layout (#101) — `sm_version` moved from byte[0] to byte[1], `vsm_version` removed entirely. Patching upstream Python had high drift cost for a project whose policy is R-primary.
@@ -114,7 +120,7 @@ subset(cuasm_insns(obj2, "vector_add"), slot == 13)
 | `kernels/gemm/hgemm/hgemm_16warp_splitk.sm_86.cubin`        | 1 | 1504  | cuda13 | ✓ |
 | `kernels/attention/flash_attention/.../flash_attn_br16_v2_pipeline_pad2.cubin`   | 1 | 1256  | cuda13 | ✓ |
 | `kernels/convolution/conv2d/conv2d_implicit_gemm_v2.sm_86.cubin`   | 1 | 1024  | cuda13 | ✓ |
-| `kernels/convolution/resblock/resblock.sm_86.cubin`                | 2 | 1232  | cuda12 | ✓ |
+| `kernels/convolution/resblock/resblock_fused.sm_86.cubin`         | 2 | 1232  | cuda12 | ✓ |
 
 Mix of CUDA 12.x and 13.x cubins, single- and multi-kernel cubins.
 
@@ -124,10 +130,12 @@ Mix of CUDA 12.x and 13.x cubins, single- and multi-kernel cubins.
 Rscript -e 'library(testthat); library(cuasmR); test_dir("R/cuasmR/tests/testthat")'
 ```
 
-Three checks:
-1. Byte-identical roundtrip on `kernels/tutorial/vector_add`.
-2. `e_flags` decoder accepts both legacy and new layouts.
-3. `cuasm_set` patches at most 8 bytes (one 64-bit word) per call.
+Five test files (`R/cuasmR/tests/testthat/`):
+- `test-roundtrip.R` — byte-identical roundtrip, `e_flags` decode (legacy + new
+  layouts), `cuasm_set` patches at most one 64-bit word per call.
+- `test-parse_throughput.R`, `test-validate_sample.R`, `test-check_regression.R`,
+  `test-bench_io.R` — the 0.2.0 measurement API (differential / characterization
+  tests against captured bench stdout fixtures).
 
 ## CLI
 
@@ -141,6 +149,30 @@ Rscript scripts/build.R roundtrip kernels/tutorial/vector_add.cu
 
 The `assemble` subcommand is a stub — point users at the `cuasm_read → cuasm_set → cuasm_write` R script pattern shown above. Text-to-bytes assembly is intentionally out of scope.
 
+## Measurement API (0.2.0, #134)
+
+0.2.0 added a packaged GPU-benchmark measurement API, migrated out of the
+`scripts/{bench,probe}` harnesses so the run → parse → validate → regress
+pipeline has one tested implementation. The seven measurement harnesses
+(`bench_regress.R`, `grid_measure.R`, `grid_collect.R`, `probe_gpu_power.R`,
+`rebaseline_measure.R`, `clock_lock_sweep.R`, `bench_flash_all.R`) now
+`library(cuasmR)` and call these 12 exports:
+
+| Group | Functions | Source |
+|---|---|---|
+| Run + parse | `run_bench`, `parse_throughput` | `R/cuasmR/R/bench_run.R` |
+| Sampling | `validate_sample`, `collect_valid_samples`, `report_median_metrics` | `R/cuasmR/R/bench_measure.R` |
+| Regression | `check_regression` | `R/cuasmR/R/bench_regression.R` |
+| JSONL store | `append_jsonl_row`, `read_jsonl` | `R/cuasmR/R/bench_io.R` |
+| GPU metadata | `capture_gpu_state`, `classify_meta`, `decode_throttle`, `summarise_meta` | `R/cuasmR/R/bench_meta.R` |
+
+Pipeline order: `run_bench` (launch + GPU-state snapshot) → `parse_throughput`
+(ms + GFLOPS/TOPS from stdout) → `validate_sample` (reject throttled / wrong-clock
+samples via `classify_meta`) → `collect_valid_samples` → `report_median_metrics`
+→ `check_regression` (vs `data/baselines.json`), with `append_jsonl_row` /
+`read_jsonl` as the per-sample store. See `docs/benchmark_methodology.md` and
+`docs/grid_sweep_methodology.md` for the measurement design.
+
 ## Comparison to upstream CuAssembler
 
 |                      | upstream Python | cuasmR (this repo) |
@@ -150,7 +182,7 @@ The `assemble` subcommand is a stub — point users at the `cuasm_read → cuasm
 | CUDA 12.x compatible         | yes                            | yes |
 | CUDA 13.x compatible         | broken (#101)                  | yes |
 | Roundtrip byte-identical     | mostly (depends on metadata)   | yes (preserves all non-text bytes) |
-| Maintenance surface          | ~5000 lines Python              | ~400 lines R |
+| Maintenance surface          | ~5000 lines Python              | ~1,100 lines R (incl. 0.2.0 measurement API) |
 | Drift on CUDA major bump     | breaks                         | tracks nvdisasm output (stable) |
 
 ## See also
@@ -159,4 +191,7 @@ The `assemble` subcommand is a stub — point users at the `cuasm_read → cuasm
 - Issue #102 — this replacement
 - `R/cuasmR/R/elf.R` — `e_flags` layout decoder (handles both formats)
 - `R/cuasmR/R/disasm.R` — nvdisasm output parser
-- `R/cuasmR/R/api.R` — exported functions
+- `R/cuasmR/R/api.R` — exported cubin read/write/patch functions
+- `R/cuasmR/R/bench_run.R`, `bench_measure.R`, `bench_regression.R`,
+  `bench_io.R`, `bench_meta.R` — the 0.2.0 measurement API (#134)
+- `R/cuasmR/NEWS.md` — 0.1.0 / 0.2.0 changelog

--- a/docs/gpu_reflections.md
+++ b/docs/gpu_reflections.md
@@ -964,7 +964,12 @@ HGEMM baseline**.
 | Tiled 128×128, scalar smem loads | 2048³ | 12,341 | 39% | `__halves2half2` fragment construction |
 | + A-fragment `ldmatrix` | 2048³ | 19,025 | 60% | `ldmatrix.sync.aligned.m8n8.x2.shared.b16` |
 | + B-fragment `ldmatrix.trans` | 2048³ | **41,930** | **131%** | `ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16` |
-| Final (4096³ validation) | 4096³ | **41,721** | **131%** | Same kernel, larger problem |
+| Final (4096³ validation) ⚠ | 4096³ | **41,721** | **131%** | Same kernel, larger problem |
+
+> **⚠ Size-label discrepancy ([#140](https://github.com/pjt222/bare-metal/issues/140)).**
+> This table labels 41,721 as a **4096³** result, but `docs/inventory.md:25`
+> labels the same 41,721 figure as **2048³**. The two surfaces disagree on the
+> size; #140 will re-measure and pin both value and size.
 
 The kernel is now **faster than dense HGEMM** — achieving the theoretical
 2x sparsity advantage in practice.

--- a/docs/grid_sweep_methodology.md
+++ b/docs/grid_sweep_methodology.md
@@ -225,10 +225,11 @@ reasons table shows why samples were dropped. Patterns:
 
 ## Future work
 
-- **#134 cuasmR migration.** `grid_measure.R` is the canonical
-  measurement function. Lands in `scripts/probe/` for now; the
-  cuasmR migration absorbs it as a package function with `R CMD
-  check` coverage.
+- ~~**#134 cuasmR migration.**~~ **Done (#134, CLOSED).** The measurement
+  primitives are now `cuasmR` package functions with `R CMD check` coverage;
+  `grid_measure.R` does `library(cuasmR)` and calls `run_bench`,
+  `parse_throughput`, `validate_sample`, `append_jsonl_row`, `read_jsonl`. The
+  script remains in `scripts/probe/` as the planner/orchestration brain.
 - **#128 OC showcase.** Grid sweep above native clock is the OC
   data source. Add `regimes: [1850, 1900, 1950]` for the
   appropriate kernels once an over-volt is dialled in.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Underlying data lives in `../data/` (`baselines.json`,
 | [`ampere_sass_reference.md`](ampere_sass_reference.md) | sm_86 instruction reference                          |
 | [`control_codes.md`](control_codes.md)             | Stall counts, barriers, yield, scoreboards               |
 | [`memory_hierarchy.md`](memory_hierarchy.md)       | GA104 memory subsystem and the 50 KB cliff               |
-| [`cuasm_r.md`](cuasm_r.md)                         | Local R package for SASS byte-level hand-edits           |
+| [`cuasm_r.md`](cuasm_r.md)                         | cuasmR 0.2.0: SASS byte-level hand-edits + benchmark measurement API |
 
 ## Tutorial series
 
@@ -61,6 +61,8 @@ prerequisite and 06 as synthesis.
 | [`gpu_reflections.md`](gpu_reflections.md)                                           | Observation catalogue. The first-person voice is a deliberate stylistic experiment; see file preamble. |
 | [`fragment_shfl_reductions.md`](fragment_shfl_reductions.md)                         | Reusable Tensor Core reduction pattern           |
 | [`benchmark_methodology.md`](benchmark_methodology.md)                               | Throttle, the 150 W power cap, clock-lock vs cooldown, reproducibility |
+| [`grid_sweep_methodology.md`](grid_sweep_methodology.md)                             | Multi-kernel × clock grid-sweep tool architecture (#135) |
+| [`rebaseline_protocol.md`](rebaseline_protocol.md)                                   | Re-baselining procedure (executed 2026-05-22; see baselines.json) |
 | [`cymatic_memory_mapping.md`](cymatic_memory_mapping.md)                             | Chladni-pattern memory layout: theory and bench  |
 | [`diffusion_primitives.md`](diffusion_primitives.md)                                 | UNet primitive inventory                         |
 | [`int8_sparse_4096_regression_analysis.md`](int8_sparse_4096_regression_analysis.md) | Companion to Observation HH                      |

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -30,6 +30,12 @@ INT8 TC = 348; see [`../AGENTS.md`](../AGENTS.md) hardware constants).
 | **Conv2d implicit GEMM**| 64×64 320ch | **1.13 ms** | **6,687**       | 3.8%    |
 | **Online FP16→INT8**    | 4096³   | —         | **17,070**          | 9.6%    |
 
+> **⚠ Sparse HGEMM 2:4 (2048³) is under measurement review — see [#140](https://github.com/pjt222/bare-metal/issues/140).**
+> The 41,721 (24.0%) headline above disagrees with section A below (line ~107)
+> and `kernels/gemm/hgemm_sparse/README.md`, which report 31.9 TFLOPS
+> dense-parity. No measured value currently arbitrates the figure or its size;
+> do not treat 41,721 as confirmed until #140 lands.
+
 > **`igemm_sparse_tiled` 4096³ — documented reference, not a regression-gated baseline.**
 > Measured 2026-05-22: **50,497 dense-equiv GFLOPS / 2.722 ms** at a
 > host-side clock lock of 1605 MHz (median of 11 clean samples,
@@ -104,7 +110,7 @@ into a register tile.
 |---|---|---:|---|
 | `kernels/gemm/sgemm/`                 | naive / tiled / register-blocked FP32 | ~1 TFLOPS at 2048³  | `FFMA` |
 | `kernels/gemm/hgemm/`                 | tiled FP16 WMMA → 16-warp persistent  | **31.9 TFLOPS** at 2048³ | `HMMA.16816.F32` |
-| `kernels/gemm/hgemm_sparse/`          | 2:4 structured sparse FP16            | 31.9 TFLOPS dense-equiv at 2048³ | `HMMA.16816.SP` |
+| `kernels/gemm/hgemm_sparse/`          | 2:4 structured sparse FP16            | 31.9 TFLOPS dense-equiv at 2048³ ⚠ conflicts with headline 41,721 — under review [#140](https://github.com/pjt222/bare-metal/issues/140) | `HMMA.16816.SP` |
 | `kernels/gemm/igemm/`                 | INT8 IMMA + cp.async pipelining       | 27.6 TOPS (8warp_256) at 2048³ | `IMMA.16816.S8.S8` |
 | `kernels/convolution/conv2d/conv2d_implicit_gemm.cu` | reshapes conv into GEMM with on-the-fly index gen | 7.2 GFLOPS at SD 64×64×320 | `HMMA.16816.F32` |
 

--- a/docs/rebaseline_protocol.md
+++ b/docs/rebaseline_protocol.md
@@ -1,8 +1,22 @@
 # Re-baseline protocol — hgemm + igemm_sparse
 
-> Status: draft handoff, 2026-05-21 | Owner: USER (controlled
-> measurement session) | Unblocks: push of 5 queued `main` commits,
-> issues #129 / #125.
+> Status: **SUPERSEDED — executed 2026-05-22**; results are in
+> `data/baselines.json`. This page is retained as the procedure record.
+> | Owner: USER (controlled measurement session) | Unblocked: push of the
+> queued `main` commits, issues #129 / #125.
+
+> **What actually happened (corrects the 2026-05-21 plan below).** The plan
+> assumed clock-locking was unavailable and that baselines would be recorded
+> at a no-lock ~1410 MHz cold-clock. That was wrong: **host-side
+> `nvidia-smi.exe -lgc` works** (#125 verdict corrected). In the executed
+> re-baseline the non-power-bound GEMM configs were recorded at **native boost**
+> (hgemm 2048³ 31789 GFLOPS @ 1740–1770 MHz, 4096³ 30397 @ 1770–1785 MHz),
+> igemm_sparse 2048³ at 36892 @ 1410 MHz, and the power-bound
+> igemm_sparse 4096³ under a **1605 MHz host-side lock** (50497 dq-GFLOPS,
+> removed from the automated gate). The `flash_attn_br16_regpv` tolerance was
+> NOT narrowed. See `docs/benchmark_methodology.md` for the host-side lock
+> mechanism. Treat the §"Recording clock" / "-lgc rejected" framing below as
+> the pre-execution plan, not the outcome.
 
 ## Why this exists
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -346,10 +346,10 @@ there's a real correctness problem. High `max_rel` alone with small `max_abs` is
 
 The `Makefile` in `kernels/tutorial/` uses Unix `make`. On Windows, use WSL:
 ```bash
-wsl -e bash -c 'export PATH=/usr/local/cuda/bin:$PATH && cd /mnt/d/dev/p/bare-metal/phase1 && make all'
+wsl -e bash -c 'export PATH=/usr/local/cuda/bin:$PATH && cd /mnt/d/dev/p/bare-metal && make tutorial'
 ```
 
-Or call the Python build script directly — it works on both platforms.
+Or run `Rscript scripts/build.R compile <kernel>.cu` from the repo root (the R-native build harness; the old Python `build.py` was retired in #102).
 
 ---
 

--- a/kernels/attention/flash_attention/README.md
+++ b/kernels/attention/flash_attention/README.md
@@ -248,11 +248,15 @@ Bc=128 crosses the 50 KB smem cliff → 1 block/SM occupancy regression. Bc=64 s
 
 ---
 
-## flash_attn_br16_v2 (current canonical, issue #29)
+## flash_attn_br16_v2 → v2_pipeline (current canonical, issue #29)
 
 The `flash_attn_br16_v2.cu` kernel is the result of a three-stage refactor
-of `flash_attn_br16_regpv` (issue #29). It is the canonical
-high-performance Flash Attention kernel.
+of `flash_attn_br16_regpv` (issue #29). A further `cp.async` double-buffer
+refactor — `flash_attn_br16_v2_pipeline.cu` — supersedes it (+14%) and is
+**the current headline kernel: 11,453 GFLOPS / 1.53 ms** at seq=1024 b=8 h=8
+(6.6% of FP16 Tensor Core peak). See the waterfall in
+[`docs/inventory.md`](../../../docs/inventory.md). The `v2` numbers below are
+the intermediate step.
 
 ### Performance (RTX 3070 Ti, sm_86)
 
@@ -263,7 +267,8 @@ high-performance Flash Attention kernel.
 | seq=2048, batch=4, heads=8 | 4.87 ms | **3.46 ms** | **1.41×** |
 | seq=4096, batch=2, heads=8 | 10.12 ms | **6.86 ms** | **1.47×** |
 
-GFLOPS plateau: ~10 TFLOPS effective (5.7% of FP16 Tensor Core peak 174 TFLOPS).
+GFLOPS plateau for `v2`: ~10 TFLOPS effective (5.7% of FP16 Tensor Core peak
+174 TFLOPS); the `v2_pipeline` successor reaches 11,453 GFLOPS / 6.6% (above).
 
 ### What Changed
 

--- a/kernels/convolution/conv2d/README.md
+++ b/kernels/convolution/conv2d/README.md
@@ -16,8 +16,6 @@ buffer, implicit GEMM eliminates it entirely.
 | `conv2d_im2col.cu`                | Im2col + WMMA HGEMM                | works, dominated by col-buffer DRAM |
 | `conv2d_implicit_gemm.cu`         | Implicit GEMM v1                   | superseded by v2 |
 | `conv2d_implicit_gemm_v2.cu`      | Implicit GEMM v2 (canonical)       | **2.18× ResBlock outlier**, Obs GG |
-| `conv2d_direct.cuasm`             | hand-tuned SASS over `conv2d.cu`   | reference for hand-edit research |
-| `wmma_gemm.cuasm`                 | WMMA primitive shared with im2col path | building block |
 
 ### Bench
 

--- a/kernels/gemm/hgemm/README.md
+++ b/kernels/gemm/hgemm/README.md
@@ -81,7 +81,7 @@ nvcc --cubin -arch=sm_86 -O2 -o hgemm.sm_86.cubin hgemm.cu
 cuobjdump -sass hgemm.sm_86.cubin | grep HMMA
 
 # Produce editable .cuasm for SASS study
-python3 ../../scripts/build.py disasm hgemm.sm_86.cubin
+Rscript ../../../scripts/build.R disasm hgemm.sm_86.cubin
 
 # Build bench
 nvcc -arch=sm_86 -O2 -o bench bench.cu -lcuda -I../common

--- a/kernels/gemm/hgemm_sparse/README.md
+++ b/kernels/gemm/hgemm_sparse/README.md
@@ -6,6 +6,11 @@ most 2 non-zeros. Encoded via NVIDIA's 2:4 sparsity primitive
 matches dense HGEMM at 2048³, regresses at 4096³ (see
 [Obs N](../../../docs/gpu_reflections.md), [Obs HH](../../../docs/gpu_reflections.md)).
 
+> **⚠ Number under review ([#140](https://github.com/pjt222/bare-metal/issues/140)).**
+> This "31.9 TFLOPS / dense-parity" figure disagrees with the 41,721 dense-equiv
+> GFLOPS (24.0% peak, ~1.31× over dense) headline in `docs/inventory.md`. Neither
+> is backed by a current measurement; #140 will re-measure and reconcile.
+
 ## Files
 
 ### Kernels

--- a/kernels/gemm/sgemm/README.md
+++ b/kernels/gemm/sgemm/README.md
@@ -12,7 +12,7 @@ Understanding its SASS is the key to understanding GPU performance.
 |---|---|---|
 | A | `naive.cu` | Simplest GEMM SASS — the multiply-accumulate loop |
 | B | `tiled.cu` | Shared memory tiling, LDS/STS, BAR.SYNC, FFMA pipeline |
-| C | `hand_tuned.cuasm` | Stall count tuning, latency hiding, software pipelining |
+| C | _planned (not yet built)_ | Stall count tuning, latency hiding, software pipelining — study `tiled.sm_86.sass` for now |
 
 ## Benchmark Results (RTX 3070 Ti Laptop, sm_86)
 
@@ -101,8 +101,9 @@ Approaching peak requires combining all of these:
 - **Stall count tuning**: reduce S values in control codes to eliminate idle cycles
 - **Software prefetch**: issue next iteration's global loads early
 
-This is what `hand_tuned.cuasm` implements. Study the tiled SASS first,
-then look at how the control codes change in the hand-tuned version.
+This is what a Stage C `hand_tuned.cuasm` would implement — it is **not yet
+built** in this directory. Study the tiled SASS (`tiled.sm_86.sass`) first to
+see where the control codes and stall counts would change.
 
 ## Build Commands
 

--- a/kernels/memory_layout/cymatic/README.md
+++ b/kernels/memory_layout/cymatic/README.md
@@ -161,7 +161,7 @@ L2 and post-warmup all accesses are L2 hits regardless of layout. The
 ## Files
 
 - `gen_cymatic_data.R` — generates `perm.bin` + `traces.bin` from R math.
-  Sources `../../scripts/cymatic/cymatic_mapping.R` and `cymatic_analyze.R`.
+  Sources `../../../scripts/cymatic/cymatic_mapping.R` and `cymatic_analyze.R`.
 - `bench.cu` — CUDA gather bench with median + scaled iters.
 - `Makefile` — `make`, `make gen`, `make run`, `make sweep`, `make clean`.
 - `results/cymatic/grids/grid{256,512,1024,2048}_{disc,square,overlayed}_results.txt` — captured benchmark output.

--- a/kernels/tutorial/README.md
+++ b/kernels/tutorial/README.md
@@ -32,7 +32,7 @@ nvcc --cubin -arch=sm_86 -O1 -o vector_add.sm_86.cubin vector_add.cu
 cuobjdump -sass vector_add.sm_86.cubin
 
 # Or use the build script (also produces editable .cuasm)
-python ../scripts/build.py all vector_add.cu
+Rscript ../../scripts/build.R all vector_add.cu
 ```
 
 ## Step 2: Understanding the SASS Output
@@ -125,7 +125,7 @@ Save the file as `vector_add.sm_86.modified.cuasm`.
 ## Step 4: Reassemble
 
 ```bash
-python ../scripts/build.py assemble vector_add.sm_86.modified.cuasm
+Rscript ../../scripts/build.R assemble vector_add.sm_86.modified.cuasm
 # produces: vector_add.sm_86.modified.reassembled.cubin
 ```
 
@@ -163,15 +163,15 @@ FMUL modification confirmed — GPU is multiplying, not adding!
 
 ## Before You Hand-Edit: Run the Roundtrip Test
 
-The roundtrip test verifies that CuAssembler can disassemble and reassemble
+The roundtrip test verifies that cuasmR can disassemble and reassemble
 the cubin without changes, producing a working binary. **Do this first.**
 
 ```bash
-python ../scripts/build.py roundtrip vector_add.cu
+Rscript ../../scripts/build.R roundtrip vector_add.cu
 ```
 
-If this fails, CuAssembler has a compatibility issue with your CUDA version.
-Check `SETUP.md` and ensure you're using CUDA 12.x.
+If this fails, cuasmR has a compatibility issue with your toolchain.
+Check `SETUP.md` and ensure you're using CUDA 13.2.
 
 ## What's Next
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,8 @@ scripts/
 ├── build.R                   ── compile / disasm / roundtrip (uses local cuasmR)
 ├── verify_setup.R            ── environment check (CUDA, GPU, cuasmR, renv)
 ├── install_cuasmR.R          ── (re)install the local cuasmR R package
+├── check_versions.R          ── assert CUDA/R version strings agree (CI gate)
+├── publish_hf.R              ── sync the kernel corpus to the HF dataset
 ├── install-hooks.sh          ── install repo-local git hooks
 │
 ├── model/                    ── analytical perf models (no GPU required)
@@ -32,14 +34,25 @@ scripts/
 │   ├── cymatic_optimize_summary.R ── tabulate optimize.R sweep output
 │   └── cymatic_fa_alignment.R ── how cymatic regions align with FA seq tiles
 │
-├── bench/                    ── benchmark harnesses (need GPU)
+├── bench/                    ── benchmark harnesses (need GPU; measurement via cuasmR, #134)
 │   ├── bench_regress.R       ── runs all benches vs data/baselines.json
+│   ├── bench_meta.R          ── GPU-state capture shim (capture_gpu_state/classify_meta now in cuasmR)
 │   ├── bench_reference.R     ── runs local reference benches vs data/reference_baselines.json
 │   ├── compare_reference.R   ── joins project baselines to local reference baselines
 │   ├── bench_flash_all.R     ── runs every FA variant in kernels/attention/flash_attention/, prints table
 │   ├── bench_imma_s02.R      ── one-off: IMMA S02 vs S04 stall comparison
 │   ├── bench_imma_s04.R      ── companion to s02
 │   └── handtune_imma_s04.R   ── byte-patch S04 → S02 via cuasmR + run
+│
+├── probe/                    ── GPU power/clock probes + grid sweep (need GPU; cuasmR, #134)
+│   ├── grid_measure.R        ── per-cell measure (multi-kernel × clock grid)
+│   ├── grid_collect.R        ── materialise the JSONL sample store → RDS
+│   ├── probe_gpu_power.R     ── read-only power/clock envelope probe
+│   ├── rebaseline_measure.R  ── hgemm + igemm re-baseline driver
+│   ├── clock_lock_sweep.R    ── clock-lock sweep for igemm 4096³
+│   ├── probe_clock_lock.R    ── probe whether host-side -lgc holds
+│   ├── run_grid_sweep.ps1    ── elevated-pwsh grid orchestrator (Ctrl+C-safe -rgc)
+│   └── run_locked_eval.ps1   ── elevated-pwsh single locked-clock eval driver
 │
 ├── profile/                  ── NCU profiling + measured roofline
 │   ├── ncu_profile.R         ── ncu wrapper for one kernel → markdown row

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,7 @@ These files validate hardware assumptions, fragment layouts, and race conditions
 | `igemm/test_inplace_race.cu` | Reproduce WAR hazard in in-place INT8 quantization |
 | `flash_attention/verify_wmma_layout.cu` | WMMA accumulator fragment layout (sm_86) |
 | `bench_regress/test_parser.R` | Parser tests for `scripts/bench/bench_regress.R` (14 groups, 32 assertions; canned bench-stdout fixtures) |
-| `bench_regress/test_meta.R`   | GPU/host metadata tests for `scripts/bench/bench_meta.R` (20 groups, 35 assertions; throttle decode + classify_meta policies; live-capture skipped without nvidia-smi) |
+| `bench_regress/test_meta.R`   | GPU/host metadata tests for the `cuasmR` GPU-state functions (20 groups, 37 assertions; throttle decode + classify_meta policies; live-capture skipped without nvidia-smi) |
 
 Build any CUDA test individually with the same `nvcc` commands used for production kernels.
 Run the R tests:


### PR DESCRIPTION
## Summary

Documentation housekeeping pass. A read-only multi-agent drift audit swept every
doc surface (25 READMEs, `docs/*.md`, the Quarto vignette, NEWS/CHANGELOG, the
GitHub description) against ground truth (the live cuasmR 20-export API,
`docs/inventory.md` canonical numbers, the `phaseN/`→family-dir reorg, merged
#134/#138 state). 40 confirmed findings (adversarially verified; 2 candidate
findings rejected, including a numbers-trap walk). This PR applies the safe
factual fixes; two number conflicts that need a fresh measurement are filed as
**#140** / **#141** and inline-flagged where they live.

## Fixed (21 files)

**Dead tools / paths**
- `python build.py` → `Rscript build.R` (`hgemm`, `tutorial` ×3, `troubleshooting`) — `build.py` was retired in #102.
- Removed phantom `.cuasm` references that exist nowhere in tree or history (`conv2d_direct`/`wmma_gemm`, sgemm `hand_tuned`).
- `resblock.sm_86.cubin` → `resblock_fused.sm_86.cubin`; cymatic source depth `../../` → `../../../`; `phase1` path → repo root; CUDA `12.x` → `13.2`.

**cuasmR 0.2.0 surfaced**
- `docs/cuasm_r.md`: new **Measurement API (0.2.0, #134)** section (12 exports, pipeline order, source map), version marker, test list (3→5 files), `~400`→`~1,100` lines, See-also.
- `scripts/README.md`: added the `probe/` block, `bench_meta.R`, `check_versions.R`, `publish_hf.R`.
- `benchmark_methodology.md`: `bench_meta.R::` → `cuasmR::` (the script path is now a shim); `grid_sweep_methodology.md`: #134 moved out of *Future work*; `CHANGELOG.md`: #134/#138 entries; `index.md`: linked 2 previously-unlinked docs.

**State**
- `CONTINUE_HERE.md`: #138 closed/merged via #139; `rebaseline_protocol.md`: **SUPERSEDED** banner — its "`-lgc` rejected / cold-clock 1410 MHz" framing was factually wrong (host-side lock works; GEMM recorded at boost, igemm under a 1605 lock).
- flash_attention README: `v2_pipeline` is canonical (11,453 GFLOPS / 1.53 ms); `tests/README` assertion count 35→37; root README `make reproduce` gains the `figures` stage.

**GitHub repo metadata** (applied separately): description now mentions cuasmR; topics `+rstats +r-package`, `−machine-code −high-performance-computing` (20-cap).

## Left for measurement (NOT auto-fixed — no inventing numbers)
- **#140** — Sparse HGEMM 2:4: `inventory.md` self-contradicts (`41,721`@2048³ vs `31.9 TFLOPS` parity) and `gpu_reflections` labels `41,721` as 4096³. No measured value arbitrates. Inline `⚠ #140` flags at all four spots.
- **#141** — INT8 IMMA peak `348` (dense, `AGENTS.md`/`inventory.md`) vs `696` (2:4-sparse, the qmd + live `igemm` bench). Convention decision spanning docs + a `.cu`. Inline `⚠ #141` flag in the qmd.

## Verification (GPU-free)
The pre-push gate and docs CI never execute these doc tools, so they don't
validate content; checked directly instead:
- `check_links.R`: **0 broken** (60 links).
- `check_versions.R`: **PASS**.
- Quarto qmd edits are table/prose + one blockquote — no code chunk touched, so the render job is safe.

Refs #134, #138 (both already closed). Does not close any issue — #140 / #141 stay open for measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
