### PR TITLE
fix(docs): #143 — locked-clock re-measure confirms sparse HGEMM 1.33× / 131%

### DIFF
--- a/docs/gpu_reflections.md
+++ b/docs/gpu_reflections.md
@@ -966,18 +966,18 @@ HGEMM baseline**.
 | + B-fragment `ldmatrix.trans` | 2048³ | **41,930** | **131%** | `ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16` |
 | Final (4096³ validation) | 4096³ | **41,721** | **131%** | Same kernel, larger problem |
 
-> **Size-label reconciled ([#140](https://github.com/pjt222/bare-metal/issues/140), 2026-06-03).**
+> **Size-label reconciled + locked-clock confirmed ([#140](https://github.com/pjt222/bare-metal/issues/140) / [#143](https://github.com/pjt222/bare-metal/issues/143), 2026-06-03).**
 > This journey table is authoritative: 41,930 @ 2048³ and 41,721 @ 4096³ (both
-> 131% of dense). `docs/inventory.md` previously copied the 4096³ figure into a
-> 2048³ row — now corrected to cite the re-measured **41,080 @ 4096³**. The
-> 2026-06-03 re-measure confirms ~41k dense-eq at both sizes and a same-session
-> matched-clock sparse/dense ratio of **1.27×** (4096³, ~1.68 GHz, both
-> power-bound). The table's historical **131%** is vs the frozen 31,910 dense
-> literal; the re-measured **1.27×** is vs same-session dense (32,327) — they
-> agree within native-boost spread. The old "31.9 TFLOPS / dense-parity" wording
-> in the kernel README was a category error (31.9 = the *dense* baseline). Absolutes are native-boost
-> and power-bound (bimodal, like `igemm_sparse_tiled`); a stable locked-clock
-> figure → [#143](https://github.com/pjt222/bare-metal/issues/143).
+> 131% of dense). `docs/inventory.md` had copied the 4096³ figure into a 2048³
+> row — corrected to 4096³. A host-side clock lock (`nvidia-smi.exe -lgc 1605`,
+> the regime free of the 150 W power-cap bimodal) **vindicates the 131%**: at
+> matched 1605 MHz 4096³, sparse dense-eq **42,257** vs dense **31,886** GFLOPS
+> = **1.33× = 133%** — and the locked dense 31,886 ≈ the frozen 31,910 literal
+> the original 131% was computed against. The old "31.9 TFLOPS / dense-parity"
+> wording in the kernel README was a category error (31.9 = the *dense*
+> baseline). The old "4096³ 0.81× regression" is **refuted**: locked, sparse
+> 4096³ (42,257) is at parity-or-above 2048³ (40,980), not a 19% drop — the
+> apparent regression was native-boost power-cap noise.
 
 The kernel is now **faster than dense HGEMM** — achieving the theoretical
 2x sparsity advantage in practice.

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -30,16 +30,18 @@ INT8 TC = 348; see [`../AGENTS.md`](../AGENTS.md) hardware constants).
 | **Conv2d implicit GEMM**| 64×64 320ch | **1.13 ms** | **6,687**       | 3.8%    |
 | **Online FP16→INT8**    | 4096³   | —         | **17,070**          | 9.6%    |
 
-> **Sparse HGEMM 2:4 — re-measured 2026-06-03 ([#140](https://github.com/pjt222/bare-metal/issues/140) resolved).**
+> **Sparse HGEMM 2:4 — measured & reconciled 2026-06-03 ([#140](https://github.com/pjt222/bare-metal/issues/140) / [#143](https://github.com/pjt222/bare-metal/issues/143)).**
 > The old "31.9 TFLOPS / dense-parity" wording (section A below / the kernel
 > README) was a category error: 31.9 TFLOPS is the *dense* HGEMM baseline, not
-> the sparse result. Same-session matched-clock 4096³ — sparse dense-eq 41,080
-> (confirms the 41,721 headline within native-boost spread) vs dense 32,327
-> GFLOPS (~1.68 GHz, both power-bound at the 150 W cap) = **1.27× over dense**,
-> between the 1× floor and 2× ceiling of 2:4 sparsity.
-> Absolutes are native-boost and power-bound (bimodal, like `igemm_sparse_tiled`
-> below); a stable locked-clock figure and the 2048³-vs-4096³ regression need an
-> elevated `nvidia-smi.exe -lgc` re-measure → [#143](https://github.com/pjt222/bare-metal/issues/143).
+> the sparse result. Under a host-side clock lock (`nvidia-smi.exe -lgc 1605`,
+> the regime free of the 150 W power-cap bimodal), matched 1605 MHz 4096³ —
+> sparse dense-eq **42,257** vs dense **31,886** GFLOPS = **1.33× over dense**
+> (= 133%, confirming the long-standing 131% in `gpu_reflections.md`; the locked
+> dense 31,886 ≈ the 31,910 literal). Between the 1× floor and 2× ceiling of 2:4
+> sparsity; the 41,721 headline (4096³) is confirmed within spread. The old
+> "4096³ 0.81× regression" is **refuted** — at matched 1605 MHz sparse 4096³ is
+> at parity-or-above 2048³ (42,257 vs 40,980), not a 19% drop; the apparent
+> regression was native-boost power-cap noise.
 
 > **`igemm_sparse_tiled` 4096³ — documented reference, not a regression-gated baseline.**
 > Measured 2026-05-22: **50,497 dense-equiv GFLOPS / 2.722 ms** at a
@@ -115,7 +117,7 @@ into a register tile.
 |---|---|---:|---|
 | `kernels/gemm/sgemm/`                 | naive / tiled / register-blocked FP32 | ~1 TFLOPS at 2048³  | `FFMA` |
 | `kernels/gemm/hgemm/`                 | tiled FP16 WMMA → 16-warp persistent  | **31.9 TFLOPS** at 2048³ | `HMMA.16816.F32` |
-| `kernels/gemm/hgemm_sparse/`          | 2:4 structured sparse FP16            | 41,721 dense-eq GFLOPS at 4096³ — 1.27× dense, matched-clock ([#140](https://github.com/pjt222/bare-metal/issues/140)) | `HMMA.16816.SP` |
+| `kernels/gemm/hgemm_sparse/`          | 2:4 structured sparse FP16            | 41,721 dense-eq GFLOPS at 4096³ — 1.33× dense, clock-locked 1605 ([#143](https://github.com/pjt222/bare-metal/issues/143)) | `HMMA.16816.SP` |
 | `kernels/gemm/igemm/`                 | INT8 IMMA + cp.async pipelining       | 27.6 TOPS (8warp_256) at 2048³ | `IMMA.16816.S8.S8` |
 | `kernels/convolution/conv2d/conv2d_implicit_gemm.cu` | reshapes conv into GEMM with on-the-fly index gen | 7.2 GFLOPS at SD 64×64×320 | `HMMA.16816.F32` |
 

--- a/kernels/gemm/hgemm_sparse/README.md
+++ b/kernels/gemm/hgemm_sparse/README.md
@@ -3,9 +3,9 @@
 FP16 GEMM where every contiguous 4-element group of operand A has at
 most 2 non-zeros. Encoded via NVIDIA's 2:4 sparsity primitive
 (`mma.sp.sync.aligned.m16n8k16` PTX, `HMMA.16816.SP` SASS).
-Dense-equivalent throughput is **~1.27× dense HGEMM** (matched-clock,
-same-session — see [Headline](#headline-rtx-3070-ti-laptop-sm_86) below),
-the structured-sparsity win (development arc:
+Dense-equivalent throughput is **~1.33× dense HGEMM** (clock-locked
+1605 MHz, 4096³ — see [Headline](#headline-rtx-3070-ti-laptop-sm_86)
+below), the structured-sparsity win (development arc:
 [Obs N](../../../docs/gpu_reflections.md), [Obs HH](../../../docs/gpu_reflections.md)).
 
 ## Files
@@ -43,34 +43,37 @@ nvcc -arch=sm_86 -O2 -o bench bench.cu -lcuda -I../common
 2:4 sparsity skips half of A's K-elements, so **dense-equivalent**
 throughput (the FLOP count the same problem would cost as dense work)
 can exceed the dense HGEMM baseline — that excess is the sparsity win.
-Re-measured 2026-06-03 (#140), `bench.cu` Dense-eq column:
+Measured under a host-side clock lock (`nvidia-smi.exe -lgc 1605,1605`,
+elevated Windows shell — the only regime free of the 150 W power-cap
+bimodal; [#143](https://github.com/pjt222/bare-metal/issues/143)),
+`bench.cu` Dense-eq column, every cell steady at 1605 MHz:
 
-| Shape  | Dense HGEMM (16-warp) | Sparse 2:4 (dense-eq) |
-|--------|----------------------:|----------------------:|
-| 2048³  | 31,948 GFLOPS @ 1.77 GHz | 40,153 GFLOPS @ 1.41 GHz |
-| 4096³  | 32,327 GFLOPS @ 1.67 GHz | 41,080 GFLOPS @ 1.69 GHz |
+| Shape  | Dense HGEMM (16-warp) | Sparse 2:4 (dense-eq) | Sparse-eq / dense |
+|--------|----------------------:|----------------------:|------------------:|
+| 2048³  | 29,259 GFLOPS | 40,980 GFLOPS | 1.40× |
+| 4096³  | 31,886 GFLOPS | 42,257 GFLOPS | **1.33×** |
 
-At **4096³** both kernels are long-running and power-bound at the 150 W
-cap, at near-identical SM clock (~1.68 GHz) → a fair same-power
-comparison: sparse-eq / dense = 41,080 / 32,327 = **1.27×**. This is the
-clock-robust headline — sparse dense-equivalent throughput is ~1.27×
-dense, between the 1× floor and 2× ceiling of 2:4 sparsity. (The 2048³
-rows are at *mismatched* clocks — sparse ran un-boosted at 1.41 GHz,
-dense at 1.77 GHz — so their raw ratio understates the sparse advantage;
-treat 4096³ as canonical.)
+**Canonical: ~1.33× over dense at 4096³** (= 133%, confirming the
+long-standing **131%** in [Obs N](../../../docs/gpu_reflections.md)) —
+sparse dense-equivalent throughput sits between the 1× floor and 2×
+ceiling of 2:4 sparsity. The 2048³ ratio (1.40×) is higher only because
+the 1605 lock sits below dense's native boost: dense HGEMM is clock-bound
+and is suppressed more by the lock than the power-bound sparse kernel, so
+treat 4096³ as canonical, not 2048³. Locked figures are stable to <0.5%
+across re-runs (vs ~1.9× bimodal at native boost — the power-cap artifact
+documented for `igemm_sparse_tiled`).
 
 > The earlier "31.9 TFLOPS / dense-parity" wording was a **category
 > error**: 31.9 TFLOPS is the *dense* HGEMM baseline (the frozen
-> reference line `bench.cu` prints), not the sparse result. On a
-> dense-equivalent basis the sparse kernel **beats** dense; it does not
-> merely match it.
+> reference line `bench.cu` prints), not the sparse result — and the
+> locked dense 4096³ (31,886) confirms that literal. On a
+> dense-equivalent basis the sparse kernel **beats** dense by ~1.33×; it
+> does not merely match.
 >
-> Absolute sparse numbers above are native-boost and power-bound
-> (bimodal on the 150 W laptop, like `igemm_sparse_tiled`). A stable
-> locked-clock absolute and the 2048³-vs-4096³ per-clock regression
-> (old "0.81×" claim — not reproducible at native boost) need an
-> elevated `nvidia-smi.exe -lgc` re-measure →
-> [#143](https://github.com/pjt222/bare-metal/issues/143).
+> The old "4096³ regresses to ~26 TFLOPS / 0.81×" claim is **refuted**:
+> at matched 1605 MHz, sparse 4096³ (42,257) is at parity-or-above 2048³
+> (40,980), not a 19% drop. The apparent regression was native-boost
+> power-cap noise, not a size effect.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary

Closes #143 — the controlled-clock re-measure that #140 deferred because
the WSL shell lacked admin to set `-lgc`. Done now under an **elevated
host-side lock** (`nvidia-smi.exe -lgc 1605,1605`), the regime free of
the 150 W power-cap bimodal. Every cell ran steady at 1605 MHz; the two
sparse cells (which carry the regression claim) reproduce to **<0.5%**.

## Locked matrix (Dense-eq GFLOPS @ 1605 MHz)

| | dense 16-warp | sparse 2:4 | sparse / dense |
|---|---:|---:|---:|
| 2048³ | 29,259 | 40,980 | 1.40× |
| 4096³ | 31,886 | 42,257 | **1.33×** |

## Findings

1. **Canonical ratio = 1.33× at 4096³ (= 133%) — vindicates the
   historical 131%.** The locked dense 4096³ (31,886) ≈ the frozen
   `31,910` literal that the gpu_reflections journey's `131%` was always
   computed against (0.07% apart). So 131% was right all along. The
   native-boost **1.27×** from #140 was the anomaly — its dense ran
   relatively hot at boost, pulling the ratio down.
2. **4096³ regression — REFUTED.** The old README claim was 4096³ =
   0.81× of 2048³ (−19%, "~26 TFLOPS"). Locked: sparse 4096³ (42,257) is
   at **parity-or-above** 2048³ (40,980). The apparent regression was
   native-boost power-cap noise, not a size effect. (Stated on the robust
   margin — not selling a "+3% faster", which is inside single-run noise.)
3. **2048³ ratio (1.40×) is lock-inflated, not canonical.** Dense HGEMM
   is clock-bound; the 1605 lock sits below its native boost and suppresses
   it more than the power-bound sparse kernel — inflating the 2048³ ratio.
   4096³ is the canonical comparison.

## Edits (3) — one ratio story across all surfaces

- `kernels/gemm/hgemm_sparse/README.md` — headline table → locked figures
  + 1.33×; intro line 1.27×→1.33×; regression refutation; lock methodology.
- `docs/inventory.md` — note → locked 1.33× confirms 131%, regression
  refuted; section-A row 1.27×→1.33× locked.
- `docs/gpu_reflections.md` — journey note → "locked 1605 vindicates 131%",
  replacing the #140 "agree within native-boost spread" bridge.

Headline `41,721 @ 4096³` (root README / inventory) **unchanged** — the
locked 42,257 confirms it within spread; no number churn.

## Verification (GPU-free)

`scripts/audit/check_links.R`: **0 broken** (62 links). No `.qmd` or
version files touched → Quarto-render + version-consistency CI unaffected.

Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
