### PR TITLE
fix(docs): #141 — standardize INT8 IMMA peak on 348 TOPS dense

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ tooling language; there are no Python run-time dependencies.
 - 46 SMs (laptop bin) / 48 SMs (desktop bin), 128 cores/SM, 64K
   32-bit registers/SM, 100 KB max shared memory/SM.
 - FP32 peak 21.7 TFLOPS, FP16 Tensor Core peak 174 TFLOPS, INT8
-  Tensor Core peak 348 TOPS, DRAM 608 GB/s, L2 4 MB.
+  Tensor Core peak 348 TOPS dense (2:4-sparse 696), DRAM 608 GB/s,
+  L2 4 MB.
 - The 50 KB shared-memory cliff is load-bearing: blocks at >50 KB
   drop to 1 block/SM (4 warps), measured 2× regression vs blocks
   at ≤50 KB (2 blocks/SM, 8 warps).

--- a/docs/analysis/kernel_architecture.qmd
+++ b/docs/analysis/kernel_architecture.qmd
@@ -70,13 +70,14 @@ performance on GA104: **registers**, **shared memory**, and **warp occupancy**.
 | DRAM bandwidth | 608 GB/s |
 | FP32 peak (FFMA) | 21.7 TFLOPS |
 | FP16 Tensor peak (HMMA) | 174 TFLOPS |
-| INT8 Tensor peak (IMMA) | 696 TOPS |
+| INT8 Tensor peak (IMMA) | 348 TOPS (dense; 2:4-sparse 696) |
 
-> **⚠ INT8 IMMA peak convention under review ([#141](https://github.com/pjt222/bare-metal/issues/141)).**
-> 696 TOPS is the 2:4-sparse-doubled figure; the *dense* INT8 IMMA peak is
-> 348 TOPS (per `AGENTS.md` / `docs/inventory.md`). The %-of-INT8-peak figures
-> in this document use the 696,000 denominator; #141 will standardize on one
-> convention across the docs and the `igemm` bench.
+> **INT8 IMMA peak convention ([#141](https://github.com/pjt222/bare-metal/issues/141), standardized 2026-06-03).**
+> All %-of-INT8-peak figures in this document use the **dense** 348 TOPS
+> denominator (per `AGENTS.md` / `docs/inventory.md`), matching the dense
+> convention used for every other precision class. 696 TOPS is the
+> 2:4-sparse-doubled ceiling, cited only where a sparse kernel reports
+> against it.
 
 ## The Occupancy Model {#sec-occupancy}
 
@@ -193,7 +194,7 @@ igemm_data <- tibble::tribble(
 ) |>
   mutate(
     kernel = factor(kernel, levels = kernel[order(order)]),
-    pct_peak = tops / 696000 * 100,
+    pct_peak = tops / 348000 * 100,
     vs_naive = tops / 10897
   )
 
@@ -213,7 +214,7 @@ ggplot(igemm_data, aes(x = kernel, y = tops / 1000, fill = stage)) +
   scale_fill_manual(values = stage_colors, name = "Optimization stage") +
   scale_y_continuous(
     labels = label_comma(suffix = "k"),
-    sec.axis = sec_axis(~ . / 696 * 100, name = "% of INT8 peak (696 TOPS)")
+    sec.axis = sec_axis(~ . / 348 * 100, name = "% of INT8 peak (348 TOPS, dense)")
   ) +
   labs(
     title = "INT8 IGEMM Optimization Progression",
@@ -350,8 +351,8 @@ registers), enabling 2 blocks/SM.
 
 ## HMMA vs IMMA: The Quantization Tax {#sec-hmma-imma}
 
-The online-quant experiment attempted to exploit INT8 Tensor Cores (4x theoretical
-throughput) for FP16 matrix multiply by performing on-the-fly quantization. This
+The online-quant experiment attempted to exploit INT8 Tensor Cores (2x theoretical
+dense throughput over FP16) for FP16 matrix multiply by performing on-the-fly quantization. This
 section analyzes why the approach ultimately lost to a properly tiled HGEMM.
 
 ```{r fig-hmma-vs-imma}
@@ -444,13 +445,13 @@ ridge_fp16 <- 174000 / bw  # AI at which FP16 peak is reached
 # Roofline lines
 roofline_x <- seq(1, 512, by = 0.5)
 fp16_roof <- pmin(roofline_x * bw, 174000)
-int8_roof <- pmin(roofline_x * bw, 696000)
+int8_roof <- pmin(roofline_x * bw, 348000)
 fp32_roof <- pmin(roofline_x * bw, 21700)
 
 roof_df <- tibble(
   ai = rep(roofline_x, 3),
   gflops = c(fp32_roof, fp16_roof, int8_roof),
-  ceiling = rep(c("FP32 (21.7 TF)", "FP16 TC (174 TF)", "INT8 TC (696 TOP)"),
+  ceiling = rep(c("FP32 (21.7 TF)", "FP16 TC (174 TF)", "INT8 TC (348 TOP)"),
                 each = length(roofline_x))
 )
 
@@ -467,7 +468,7 @@ ggplot() +
   scale_color_manual(values = c(
     "FP32 (21.7 TF)" = gpu_grey,
     "FP16 TC (174 TF)" = gpu_blue,
-    "INT8 TC (696 TOP)" = gpu_green
+    "INT8 TC (348 TOP)" = gpu_green
   )) +
   annotation_logticks(sides = "bl") +
   labs(
@@ -489,7 +490,7 @@ arithmetic intensity to saturate the Tensor Cores.
 This explains why the 16-warp HGEMM at 128 ops/byte achieves only ~10.7% of
 FP16 peak: at 22% of machine balance, throughput is capped by DRAM bandwidth.
 The IGEMM 8-warp 128x256 kernel (192 ops/byte, 67% of balance) does better at
-4.0% of INT8 peak. **The next optimization target is increasing arithmetic
+7.9% of INT8 peak (dense 348 TOPS). **The next optimization target is increasing arithmetic
 intensity** via asymmetric tiles (256x128 → 85 ops/byte) or larger BK.
 
 ## The Inner Loop Length Rule {#sec-inner-loop}
@@ -590,7 +591,7 @@ the naive HGEMM used no tiling, no pipelining, and no occupancy optimization.
 Once the HGEMM path received the same treatment (128x128 tiles, cp.async,
 16-warp occupancy), it matched and then exceeded the online-quant path by ~10%.
 
-The structural cause: IMMA's 4x theoretical advantage is consumed by:
+The structural cause: IMMA's 2x theoretical (dense) advantage is consumed by:
 
 - **Double accumulator cost** (INT32 + FP32 running) = 128 registers minimum
 - **Quantization overhead** (~32% of tile time for max_abs + scale + convert)

--- a/docs/gpu_reflections.md
+++ b/docs/gpu_reflections.md
@@ -816,12 +816,12 @@ Key design decisions:
    for accumulators alone. Forces 128×128 tiles (not 128×256) to stay under 255 regs.
 2. **Block-wide max_abs reduction**: 3 extra __syncthreads per K-tile (2 for separate
    A/B reductions, 1 after quantization). ~200 cycles overhead per tile vs ~500 cycles
-   IMMA = ~40% overhead. The 4× theoretical INT8/FP16 ratio absorbs this easily.
+   IMMA = ~40% overhead. The 2× theoretical INT8/FP16 ratio (dense) absorbs this easily.
 3. **Smem layout**: FP16 double-buffer (32 KB) + INT8 working (8 KB) + epilogue (8 KB)
    = 48 KB exactly (aliased reduction scratch into epilogue to fit under static limit).
 **The HGEMM baseline is naive (no tiling, no pipelining). A tiled HGEMM would narrow
 the gap, but the online-quant kernel is also using only 128×128 tiles — both have room
-to grow. The architectural advantage (4× INT8 throughput) is fundamental.**
+to grow. The architectural advantage (2× INT8 throughput, dense) is fundamental.**
 
 **Insight 22: In-place FP16→INT8 quantization saves registers, not just smem.**
 The original online-quant kernel used separate INT8 buffers (8 KB smem, 239 regs).

--- a/kernels/gemm/igemm/README.md
+++ b/kernels/gemm/igemm/README.md
@@ -2,36 +2,36 @@
 
 ## Why INT8
 
-INT8 Tensor Cores deliver 4× the throughput of FP16 on the same silicon:
+INT8 Tensor Cores deliver 2× the throughput of FP16 on the same silicon (dense; 4× with 2:4 sparsity):
 
 | Precision | Peak Throughput | SASS Instruction |
 |-----------|----------------|------------------|
 | FP32 FFMA | 21.7 TFLOPS | `FFMA` |
 | FP16 Tensor | 174 TFLOPS | `HMMA.16816.F32` |
-| INT8 Tensor | 696 TOPS | `IMMA.16816.S8.S8` |
+| INT8 Tensor | 348 TOPS (dense; 2:4-sparse 696) | `IMMA.16816.S8.S8` |
 
 INT8 is the inference workhorse: weights and activations quantized to 8-bit, accumulated in INT32, then dequantized to FP32 for the next layer.
 
 ## Measured Results (RTX 3070 Ti Laptop, sm_86)
 
-| Kernel | 4096³ Time | TOPS | % INT8 Peak | vs Naive |
-|--------|-----------|------|-------------|----------|
-| Naive (global loads) | 12.5 ms | 10,980 | 1.6% | 1.00× |
-| Tiled 64×64 (compiler) | 9.1 ms | 15,121 | 2.2% | 1.38× |
-| Tiled 64×64 (hand-tuned S02) | 9.0 ms | 15,341 | 2.2% | 1.40× |
-| Tiled 64×64 (aggressive S01) | 9.1 ms | 15,170 | 2.2% | 1.38× |
-| Register-blocked 128×128 | 10.8 ms | 12,741 | 1.8% | 1.16× |
-| Pipelined LDG (double-buffer) | 7.6 ms | 18,054 | 2.6% | 1.64× |
-| **Pipelined cp.async (double-buffer)** | **6.6 ms** | **20,688** | **3.0%** | **1.88×** |
-| 8-warp 128×128 (1 blk/SM) | 5.6 ms | 24,533 | 3.5% | 2.21× |
-| 8-warp 128×256 (1 blk/SM) | **5.0 ms** | **27,591** | **4.0%** | **2.49×** |
-| Persistent 128×256 (L2) | 5.0 ms | 27,383 | 4.0% | 2.47× |
+| Kernel | 4096³ Time | TOPS | % INT8 Peak (dense 348) | vs Naive |
+|--------|-----------|------|-------------------------|----------|
+| Naive (global loads) | 12.5 ms | 10,980 | 3.2% | 1.00× |
+| Tiled 64×64 (compiler) | 9.1 ms | 15,121 | 4.3% | 1.38× |
+| Tiled 64×64 (hand-tuned S02) | 9.0 ms | 15,341 | 4.4% | 1.40× |
+| Tiled 64×64 (aggressive S01) | 9.1 ms | 15,170 | 4.4% | 1.38× |
+| Register-blocked 128×128 | 10.8 ms | 12,741 | 3.7% | 1.16× |
+| Pipelined LDG (double-buffer) | 7.6 ms | 18,054 | 5.2% | 1.64× |
+| **Pipelined cp.async (double-buffer)** | **6.6 ms** | **20,688** | **5.9%** | **1.88×** |
+| 8-warp 128×128 (1 blk/SM) | 5.6 ms | 24,533 | 7.0% | 2.21× |
+| 8-warp 128×256 (1 blk/SM) | **5.0 ms** | **27,591** | **7.9%** | **2.49×** |
+| Persistent 128×256 (L2) | 5.0 ms | 27,383 | 7.9% | 2.47× |
 
 FP16 HGEMM reference: **31,910 GFLOPS** at 4096³ (hgemm_16warp).
 
 **Why tiled 64×64 beats register-blocked 128×128:** The 128×128 kernel's inner loop has 16 mma_sync calls per K-step (vs 4 for 64×64). This long IMMA chain reduces warp switching frequency. With only 8 warps/SM (4 warps × 2 blocks), the scheduler can't fully hide Tensor Core pipeline latency (S08 stalls). The 64×64 version's shorter inner loop allows faster warp interleaving — same lesson as the Bc=128 Flash Attention experiment.
 
-**Why only 4.0% of INT8 peak?** The tiled kernel without pipelining was fully bandwidth-bound: 2 GB at 608 GB/s = ~3.3 ms floor vs 9.0 ms total. Software pipelining (double-buffered smem) overlaps LDG for tile N+1 with IMMA compute on tile N, reclaiming ~2.4 ms of pipeline bubble. The 128×256 variant with 1 block/SM (8 warps) achieves the best balance of compute density vs occupancy. The remaining gap to the 0.2 ms compute minimum is still dominated by DRAM bandwidth.
+**Why only 7.9% of INT8 peak?** (dense 348 TOPS basis.) The tiled kernel without pipelining was fully bandwidth-bound: 2 GB at 608 GB/s = ~3.3 ms floor vs 9.0 ms total. Software pipelining (double-buffered smem) overlaps LDG for tile N+1 with IMMA compute on tile N, reclaiming ~2.4 ms of pipeline bubble. The 128×256 variant with 1 block/SM (8 warps) achieves the best balance of compute density vs occupancy. The remaining gap to the 0.2 ms compute minimum is still dominated by DRAM bandwidth.
 
 See [`docs/gpu_reflections.md`](../../../docs/gpu_reflections.md) for the full optimization timeline (Insight 12: "IMMA pipelining is memory-bound until tile size grows", Insight 20: "L2 reuse from persistent grid is negligible").
 

--- a/kernels/gemm/igemm/bench.cu
+++ b/kernels/gemm/igemm/bench.cu
@@ -9,8 +9,8 @@
  *   ./bench [M] [N] [K]
  *   ./bench 4096 4096 4096   # default — large enough to saturate Tensor Cores
  *
- * Expected: ~4× improvement over FP16 HGEMM in throughput (TOPS).
- * Theoretical: 696 TOPS INT8 / 174 TFLOPS FP16 = 4×
+ * Expected: ~2× improvement over FP16 HGEMM in throughput (TOPS) — dense.
+ * Theoretical (dense): 348 TOPS INT8 / 174 TFLOPS FP16 = 2× (2:4-sparse: 696 TOPS, 4×)
  */
 
 #include <cstdio>
@@ -642,7 +642,7 @@ int main(int argc, char **argv) {
     int bench_iters  = 50;
     printf("\nPerformance (avg of %d runs, %d warmup):\n", bench_iters, warmup_iters);
 
-    double int8_peak_tops  = 696000.0;  // RTX 3070 Ti INT8 Tensor Core peak
+    double int8_peak_tops  = 348000.0;  // RTX 3070 Ti dense INT8 TC peak (2:4-sparse ceiling 696000)
     double fp16_peak_gflops = 174000.0;
 
     void *bench_args[] = { &dev_a_int8, &dev_b_int8, &dev_c, &M, &N, &K, &scale_a, &scale_b };

--- a/kernels/gemm/igemm/igemm.cu
+++ b/kernels/gemm/igemm/igemm.cu
@@ -6,7 +6,7 @@
  *
  * Why INT8 Tensor Cores?
  *   FP16 Tensor peak:  ~174  TFLOPS  (HMMA.16816.F32)
- *   INT8 Tensor peak:  ~696  TOPS    (IMMA.8816.S8 — 4× throughput, same silicon)
+ *   INT8 Tensor peak:  ~348  TOPS    (IMMA.8816.S8 — 2× FP16 throughput dense, same silicon; 2:4-sparse 696)
  *
  * INT8 is the inference workhorse: weights and activations quantized to 8-bit,
  * accumulated in INT32, then dequantized back to FP32 for the next layer.


### PR DESCRIPTION
## Summary

Closes #141. Standardizes the INT8 IMMA peak convention across docs +
the `igemm` bench: **%-of-peak denominators use the dense 348 TOPS peak**
everywhere (matching how FP16's 174 TFLOPS *dense* peak is the basis for
every other precision class); the 2:4-sparse-doubled **696 TOPS** is cited
only as an explicitly-labeled sparse ceiling.

`docs/inventory.md` already used 348 (IGEMM 7.9%, sparse-INT8 11.4%), so it
was the reference — the other surfaces were the drift, splitting 348/696
inconsistently. After this PR every surface tells one story.

## Why 348 dense

Dense INT8 IMMA = 2× dense FP16 (same silicon, 8-bit packs 2× the MACs):
348 / 174 = 2×. The 696 figure is 348 × 2 again for 2:4 structured sparsity
(so INT8 + 2:4 = 4× FP16 — that compound claim is correct and kept). Using
696 as a plain %-peak denominator silently halved every INT8 kernel's
reported utilization.

## Changes (6 files)

- **`AGENTS.md`** — canonical constant → `348 TOPS dense (2:4-sparse 696)`.
  Root-cause fix: #141 existed because this source-of-truth left 348 bare.
- **`docs/analysis/kernel_architecture.qmd`** — HW table 696→348; resolved
  the ⚠ #141 blockquote; **code chunks** `pct_peak` / `sec.axis` / roofline
  ceiling `696000`→`348000` + ceiling labels; prose `4x`→`2x` (×2); igemm
  prose `4.0%`→`7.9%`.
- **`kernels/gemm/igemm/{bench.cu, igemm.cu, README.md}`** — peak constant
  `696000.0`→`348000.0`; README `% INT8 Peak` column recomputed to the 348
  basis (10 rows; best kernel 27,591 TOPS → **7.9%**, = inventory); dense
  `4×`→`2×` framing.
- **`docs/gpu_reflections.md`** — two `4× INT8/FP16` claims → `2× (dense)`.

**Untouched (correct as-is):** `inventory.md` (already 348 — the reference);
`tutorial/03` (`INT8 + 2:4 = 4×` and "2× the FP16 peak" both right);
`sass_histogram.md` 696 (an instruction count, not a peak).

## Verification (GPU-free)

- **Re-rendered the qmd locally** (CI uses the same `quarto render`, freeze
  off → re-executes fresh). Rendered HTML shows **"7.9% of INT8 peak (dense
  348 TOPS)"** and **"348 TOPS (dense; 2:4-sparse 696)"** — no stale 4.0% /
  696-axis. The discriminating check (qmd igemm == inventory's 7.9%) passes.
- `bench.cu` compiles (`nvcc -arch=sm_86 -O2`).
- `check_links.R`: 0 broken (62 links).

Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
