### PR TITLE
feat(bench): #124 — bench-all full-corpus runner (skip nothing, record everything)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,19 @@ bench_*
 # under kernels/, not here, so they stay ignored).
 !scripts/bench/
 !scripts/bench/*.R
+# bench_all.R reads its corpus spec from scripts/bench/bench_all.yml; the
+# `bench_*` rule would swallow the .yml (the *.R re-include above is R-only).
+!scripts/bench/*.yml
 # The cuasmR package R/ sources include bench_*.R files (issue #134
 # measurement migration); re-include them — they are library code, not
 # compiled bench artifacts.
 !R/cuasmR/R/bench_*.R
 !tests/bench_regress/
 !tests/bench_regress/**
+# tests/bench_all/ (issue #124) is swallowed by `bench_*` too — re-include
+# the GPU-free unit tests (results/bench_all/ generated output stays ignored).
+!tests/bench_all/
+!tests/bench_all/**
 test_dense_manual
 test_mma_sp
 test_inplace_race

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ historical reference.
 
 ## Unreleased
 
+### Added
+- **`make bench-all` full-corpus runner (#124).** New on-demand "run
+  everything" pass: `scripts/bench/bench_all.R` discovers the whole
+  `$(BENCH_EXES)` corpus, runs every bench, and records every attempt +
+  per-config summary + run metadata to
+  `results/bench_all/<timestamp>/{results.json,summary.md,samples.jsonl}`.
+  Skip nothing, record everything (docs/benchmark_methodology.md). Reuses
+  the cuasmR measurement API (no reimplementation). Per-bench invocation +
+  output-parse hints live in `scripts/bench/bench_all.yml` (all 48 corpus
+  exes specced). Benches that emit no single number (A/B sweep tables,
+  ms-only pipelines, correctness harnesses) are tagged `non-measurable`
+  and run once; un-runnable ones (cuDNN-SDPA stub, cymatic needs data
+  files) are documented-`skipped` — neither is reported as a kernel
+  `failed`. Each entry carries a `verified`/`infer` flag separating
+  baseline-confirmed specs from source-inferred ones. The fast regression
+  gate (`make bench` / `bench_regress.R`) is unchanged. GPU-free unit
+  tests in `tests/bench_all/`.
+
 ### Changed
 - **cuasmR measurement-API migration (#134, cuasmR 0.1.0 → 0.2.0).** The
   benchmark run → parse → validate → regress logic was migrated out of the

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ REGRESS_BENCH := \
 # Default target
 # ------------------------------------------------------------------
 .PHONY: all cubins benches test clean disasm sass help \
-        setup verify bench bench-reference compare-reference reference-pipeline reproduce figures \
+        setup verify bench bench-all bench-reference compare-reference reference-pipeline reproduce figures \
         publish-hf \
         tutorial gemm reductions attention convolution elementwise memory_layout composition reference
 
@@ -203,6 +203,23 @@ verify:
 
 bench:
 	@$(RSCRIPT) scripts/bench/bench_regress.R
+
+# Full-corpus "run everything" pass (#124). Builds the whole corpus, then
+# runs every bench and records every result + metadata to
+# results/bench_all/<timestamp>/ (results.json, summary.md, samples.jsonl).
+# On-demand data collection -- NOT the regression gate (that stays `make
+# bench` / bench_regress.R, unchanged). Skip nothing, record everything.
+# Extra flags: make bench-all ARGS="--min-valid 3 --max-attempts 10"
+# Plan only (no GPU): make bench-all ARGS=--list   (or run bench_all.R directly)
+#
+# The build is best-effort (`-k` keep-going, `-` ignore failure): a corpus
+# bench that can't compile (e.g. a reference bench on a box without
+# cuSPARSELt/cuDNN) must NOT abort the pass -- bench_all.R records it
+# `not-built` and continues. Aborting here would defeat the whole
+# skip-nothing principle (the recipe would never run).
+bench-all:
+	-@$(MAKE) -k all
+	@$(RSCRIPT) scripts/bench/bench_all.R $(ARGS)
 
 figures:
 	@echo "=== Regenerating docs/figures ==="

--- a/docs/CONTINUE_HERE.md
+++ b/docs/CONTINUE_HERE.md
@@ -1,9 +1,98 @@
 # Session handoff
 
-> Last updated: 2026-06-03T18:10Z (#142 merged; **#140 / #143 / #141 all
-> CLOSED** — sparse HGEMM 2:4 measured + clock-locked, INT8 peak standardized.
-> main clean at `1361fc1`. Use WSL Linux R, not Windows Rscript.exe.) |
-> Branch: `docs/session-handoff-2026-06-03`
+> Last updated: 2026-06-04 (#124 bench-all runner BUILT + GPU-validated on
+> branch `feat/124-bench-all` — NOT pushed/PR'd yet. Native GPU pass ran;
+> infer hints confirmed, 1 fixed (cusparselt); ~16 benches blocked by a
+> PRE-EXISTING cubin-name mismatch = candidate new issue, not #124.)
+> Use WSL Linux R (`/usr/local/bin/Rscript` 4.6.0), not Windows Rscript.exe.
+
+## ▶ SESSION — 2026-06-04 — #124 bench-all full-corpus runner
+
+**Where we "broke off":** nowhere in git — the prior session landed
+everything clean (#140/#143/#141 + handoff PR #147 all merged, `919f0e1`,
+tree clean, no stash/worktree). The two divergent branches are dead:
+`refactor/bench-driver` (2026-05-05, pre-reorg, 46k-line revert) and
+`feat/138-comparison-harness-consolidation` (tip `dfa5d07` already an
+ancestor of main via PR #139). Both safe to prune. "Continue" = next item
+in the handoff queue. User picked **#124** (the only Claude-buildable item;
+#135/#128 need an elevated Windows GPU shell).
+
+**Built (branch `feat/124-bench-all`; includes a 4-lens adversarial review
+pass + advisor fixes):**
+- `scripts/bench/bench_all.R` — `make bench-all` full-corpus runner.
+  Discovers the corpus exactly as `$(BENCH_EXES)` (shell-free), runs every
+  bench, retries each measurable config to `--min-valid` via the cuasmR
+  pipeline (`run_bench → parse_throughput → validate_sample →
+  collect_valid_samples → report_median_metrics`), never aborts, writes
+  `results/bench_all/<ts>/{results.json,summary.md,samples.jsonl}`. Reuses
+  the cuasmR API; reimplements nothing.
+- `scripts/bench/bench_all.yml` — all **48** corpus exes specced (50 configs:
+  hgemm + igemm_sparse each at 2 sizes). 32 measurable, 16 `non-measurable`
+  (A/B sweep tables / ms-only pipelines / correctness harnesses → run once,
+  parse-miss expected, never `failed`), 2 `run:false` (cuDNN-SDPA stub,
+  cymatic needs perm.bin/traces.bin). `verified` vs `infer` flag separates
+  baseline/sweep-confirmed specs (7) from source-inferred (the rest).
+- `make bench-all` target (`: all` first); `.gitignore` re-includes
+  `scripts/bench/*.yml` + `tests/bench_all/` (the `bench_*` rule swallowed
+  them, cf. #134); generated `results/bench_all/` stays ignored.
+- Docs: `docs/benchmark_methodology.md` "run everything" section now points
+  at the implementation; `CHANGELOG.md` Added entry; `scripts/README.md`.
+- `tests/bench_all/test_bench_all.R` — **55 GPU-free assertions, all pass**
+  (Linux R 4.6.0): corpus discovery, spec merge, status/aggregation, render
+  bucket separation (= the advisor invariant), full-spec corpus coverage.
+
+**Provenance / method (negative space):**
+- Corpus arg-contracts + output formats mapped by a 13-agent workflow over
+  all 48 bench.cu; reviewed by a 4-lens adversarial workflow. The review's
+  one actionable hit (summarise_config hardcoded `measurable=TRUE`) is fixed;
+  its "NULL-post crashes attempt_row" finding was a **false positive** —
+  empirically `NULL$gpu$throttle` returns NULL in R (the "$ invalid for
+  atomic vectors" error is for atomic vectors, not NULL).
+- **The make-or-break (advisor):** a non-perf/inferred/default parse-miss must
+  never read as a real kernel failure. Handled by the measurable/non-measurable/
+  skipped taxonomy + verified/infer flag + three segregated report buckets.
+
+**GPU validation pass DONE** (`make bench-all --min-valid 3 --max-attempts 6`,
+native, no elevation needed; run `results/bench_all/20260604T103311/`):
+ok=18, degraded=2, failed=19, non-measurable=9, skipped=2.
+- **infer parse hints confirmed** for the bulk: sgemm, conv2d_nhwc,
+  igemm_sparse_persistent, flash_attn_multihead, cross_attn_pipelined,
+  all GB/s reductions (groupnorm/layernorm/softmax) + activations +
+  timestep_emb, and the cuBLAS/cuDNN references. hgemm_aligned/epi_pad
+  parsed too (just throttled).
+- **One hint bug found + fixed:** `ref_cusparselt_igemm_sparse` was
+  `value_label: "dense-equiv TOPS"`, but the data line prints plain
+  `TOPS` (the "dense-equiv" wording is header-only) → was `parse-fail`,
+  now `170 TOPS ok` with `value_label: "TOPS"`. Folded into the feature commit.
+- **Expected throttle:** hgemm_aligned/epi_pad/igemm_cpasync/igemm_sparse_4096
+  at 4096³ `degraded`/`failed` on `SwPowerCap` at native — documented, fair
+  numbers need the host-side -lgc lock.
+- **PRE-EXISTING build-graph finding (NOT #124):** ~16 benches `failed`/
+  crashed on `cuModuleLoad ... file not found` — the BenchDriver-refactored
+  flash + resblock + attention_layer benches load ABBREVIATED cubin names the
+  build never emits (`flash_wmma`→`flash_attn_wmma`, `flash_fused`→
+  `flash_attn_fused`, `resblock`→only `resblock_fused` exists, etc.). Same
+  class as #127 (which fixed only bench_br16_regpv). bench-all surfaced it
+  exactly as designed; these were never in `make test`'s smoke loop.
+  **→ file a dedicated issue** (cubin-name realignment across the refactored
+  benches); do not fix in #124.
+
+**Next steps:**
+1. **File the cubin-name-mismatch issue** (#127-class): bench_wmma/bench_br16/
+   bench_fused/bench_split_q/bench_pipeline/bench_bc128 + resblock{,_implicit,
+   _implicit_v2} + attention_layer + flash v2_* load cubin basenames the
+   Makefile never produces. List in `results/bench_all/20260604T103311/
+   summary.md` (the `failed`/crash rows). Once fixed, those infer specs
+   re-validate via `make bench-all`.
+2. Push `feat/124-bench-all` (pre-push gate = `make test` + bench_regress,
+   GPU; watch the wedged-CUDA hang gotcha) → `gh pr create`. PR references
+   #124 WITHOUT a close keyword (epic stays open).
+3. Optional: a full `make bench-all` (default `--min-valid 5`) for
+   publication-grade medians once the cubin issue is fixed.
+4. **#135** P2-5/P2-6 grid sweep (elevated pwsh) and **#128** OC showcase
+   remain — both need the elevated Windows GPU shell.
+
+---
 
 ## ▶ SESSION END — 2026-06-03 (eve) — sparse-HGEMM measurement + INT8 convention
 

--- a/docs/benchmark_methodology.md
+++ b/docs/benchmark_methodology.md
@@ -239,9 +239,35 @@ flag, host, OS / WSL build, `nvcc` and driver versions, GPU name +
 SM count, clock-lock state, **GPU mode (hybrid / dGPU)**, and the
 per-attempt `capture_gpu_state()` snapshots.
 
-This methodology is the design basis for the planned `make
-bench-all` target — see the benchmark-pipeline hardening issues on
-GitHub.
+This methodology is implemented by **`make bench-all`** →
+`scripts/bench/bench_all.R` (issue #124). It discovers the corpus
+exactly as `$(BENCH_EXES)`, drives each measurable bench through the
+cuasmR pipeline (`run_bench → parse_throughput → validate_sample →
+collect_valid_samples → report_median_metrics`), and writes
+`results/bench_all/<timestamp>/{results.json,summary.md,samples.jsonl}`
+with the run metadata above. Per-bench invocation + output-parse hints
+live in `scripts/bench/bench_all.yml`.
+
+Two honest categories beyond `degraded`/`failed`, so a non-perf bench
+never masquerades as a kernel failure (the spec tags each):
+
+- **`non-measurable`** — A/B sweep tables, ms-only composed pipelines,
+  and correctness harnesses emit no single parseable number. They are
+  run **once** to confirm they execute; a parse miss is expected, not a
+  failure.
+- **`skipped`** — benches that cannot run meaningfully here (a stub
+  library, or one needing external data files) are documented-skipped.
+
+Each spec entry also carries `verified` — `true` when its args + parse
+hint are confirmed by a recorded baseline/sweep number, else `infer`
+(read from the bench source; the first GPU run confirms it). A
+parse-fail on an `infer` row is a spec-hint bug to fix in
+`bench_all.yml`, not a real kernel failure.
+
+`make bench` / `bench_regress.R` stays the fast regression gate (the 5
+baselined kernels); `bench-all` is the on-demand "collect everything"
+pass. For clock/power context around a run, see
+`scripts/probe/probe_gpu_power.R`.
 
 For the concrete step-by-step procedure to re-record a suspect
 baseline (currently `hgemm` + `igemm_sparse`, recorded under a

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,7 +35,9 @@ scripts/
 │   └── cymatic_fa_alignment.R ── how cymatic regions align with FA seq tiles
 │
 ├── bench/                    ── benchmark harnesses (need GPU; measurement via cuasmR, #134)
-│   ├── bench_regress.R       ── runs all benches vs data/baselines.json
+│   ├── bench_regress.R       ── runs all benches vs data/baselines.json (the fast gate)
+│   ├── bench_all.R           ── full-corpus "run everything" pass → results/bench_all/ (#124)
+│   ├── bench_all.yml         ── per-bench invocation + parse spec for bench_all.R
 │   ├── bench_meta.R          ── GPU-state capture shim (capture_gpu_state/classify_meta now in cuasmR)
 │   ├── bench_reference.R     ── runs local reference benches vs data/reference_baselines.json
 │   ├── compare_reference.R   ── joins project baselines to local reference baselines

--- a/scripts/bench/bench_all.R
+++ b/scripts/bench/bench_all.R
@@ -1,0 +1,635 @@
+#!/usr/bin/env Rscript
+# bench_all.R - one-click full-corpus benchmark runner (issue #124).
+#
+# Runs EVERY bench executable in the kernel corpus and records every
+# result with full metadata. The guiding principle (docs/benchmark_
+# methodology.md, "Methodology for a full run everything pass") is
+# SKIP NOTHING, RECORD EVERYTHING:
+#
+#   - Discover the whole corpus the same way the Makefile builds it
+#     ($(BENCH_EXES): every bench.cu + kernels/**/bench_*.cu).
+#   - Per measurable config, retry up to --max-attempts until --min-valid
+#     clean samples are collected; classify each attempt from its pre/post
+#     capture_gpu_state() snapshot + exit code; cool down (adaptive)
+#     between attempts.
+#   - Never abort the corpus: a config that cannot reach --min-valid is
+#     `degraded`; one that fails every attempt is `failed`; a missing exe
+#     is `not-built`. The runner continues regardless.
+#   - Output keeps EVERY attempt (samples.jsonl + results.json) plus a
+#     per-config summary, so "no failures" is a property the reader
+#     verifies from a complete report, not a guarantee baked into the run.
+#
+# This is the on-demand "collect everything" pass. `make bench` /
+# bench_regress.R stays the fast regression gate (5 baselined kernels).
+# For clock/power context around a run, see scripts/probe/probe_gpu_power.R.
+#
+# Measurement reuses the cuasmR package API (issue #134): run_bench,
+# parse_throughput, capture_gpu_state, classify_meta, validate_sample,
+# collect_valid_samples, report_median_metrics, append_jsonl_row. Nothing
+# measurement-related is reimplemented here.
+#
+# NOT every bench in the corpus emits a single parseable throughput
+# number. The spec (scripts/bench/bench_all.yml) tags each exe:
+#   measurable: false  -> A/B sweep table / ms-only / correctness harness:
+#                         run ONCE to confirm it executes, status
+#                         `non-measurable` (a parse miss here is EXPECTED,
+#                         never a `failed`).
+#   run: false         -> cannot run meaningfully here (stub library,
+#                         needs external data): documented `skipped`.
+# An exe with NO spec entry is still run, with --default-args + a generic
+# parse, flagged spec_source="default" and reported in a SEPARATE bucket --
+# a `failed` there means "the default args were probably wrong", NOT a real
+# kernel failure. Never read the buckets as the same kind of failure.
+#
+# Usage:
+#   Rscript scripts/bench/bench_all.R                  # full corpus
+#   Rscript scripts/bench/bench_all.R --list           # plan only, no GPU
+#   Rscript scripts/bench/bench_all.R --only hgemm_16warp_2048
+#   Rscript scripts/bench/bench_all.R --min-valid 3 --max-attempts 10
+
+suppressPackageStartupMessages({
+  library(jsonlite)
+  library(yaml)
+})
+
+# GPU + host state, run, parse, validate, collect, median, JSONL: all
+# from cuasmR (issue #134). LD_LIBRARY_PATH WSL guard is in cuasmR .onLoad.
+suppressMessages(library(cuasmR))
+
+`%||%` <- function(a, b) if (is.null(a) || length(a) == 0L) b else a
+
+# ----------------------------------------------------------------------
+# Repo root: walk up from the script dir until a .git / renv.lock marker
+# (same resilient resolver as bench_regress.R).
+# ----------------------------------------------------------------------
+REPO_ROOT <- {
+  args_full <- commandArgs(trailingOnly = FALSE)
+  fa <- grep("^--file=", args_full, value = TRUE)
+  start <- if (length(fa)) normalizePath(dirname(sub("^--file=", "", fa[1])))
+           else            normalizePath(getwd())
+  cur <- start
+  repeat {
+    if (file.exists(file.path(cur, ".git")) ||
+        file.exists(file.path(cur, "renv.lock"))) break
+    parent <- dirname(cur)
+    if (parent == cur) { cur <- start; break }
+    cur <- parent
+  }
+  cur
+}
+
+DEFAULT_SPEC   <- file.path(REPO_ROOT, "scripts", "bench", "bench_all.yml")
+BASELINES_PATH <- file.path(REPO_ROOT, "data", "baselines.json")
+
+# Project-wide default fairness gate, shared with the regression gate:
+# reject any sample whose pre/post GPU state shows a non-idle throttle.
+# Read from baselines.json so bench_all and bench_regress agree.
+DEFAULT_VALID_WHEN <- local({
+  vw <- list(require_no_throttle = TRUE, allow_throttle = c("GpuIdle"))
+  if (file.exists(BASELINES_PATH)) {
+    b <- tryCatch(jsonlite::fromJSON(BASELINES_PATH, simplifyVector = FALSE),
+                  error = function(e) NULL)
+    if (!is.null(b$default_valid_when)) {
+      dvw <- b$default_valid_when
+      dvw$comment <- NULL
+      vw <- dvw
+    }
+  }
+  vw
+})
+
+# ======================================================================
+# Pure functions (GPU-free, unit-tested in tests/bench_all/).
+# ======================================================================
+
+#' Discover the full bench corpus exactly as the Makefile's $(BENCH_EXES):
+#' every `bench.cu` under the repo (excluding tools/, experiments/, renv/,
+#' .git/) + every `kernels/**/bench_*.cu`. Returns repo-relative .cu
+#' source paths, sorted+unique. Shell-free so the test runs on any box.
+discover_corpus <- function(root) {
+  prune <- c("tools", "experiments", "renv", ".git")
+  all_cu <- list.files(root, pattern = "\\.cu$", recursive = TRUE,
+                       full.names = FALSE)
+  if (!length(all_cu)) return(character(0))
+  top <- vapply(strsplit(all_cu, "/", fixed = TRUE), `[`, character(1), 1L)
+  all_cu <- all_cu[!(top %in% prune)]
+  base <- basename(all_cu)
+  is_bench   <- base == "bench.cu"
+  is_variant <- grepl("^bench_.*\\.cu$", base) & startsWith(all_cu, "kernels/")
+  sort(unique(all_cu[is_bench | is_variant]))
+}
+
+#' exe path for a bench .cu source (strip the .cu).
+exe_for_src <- function(src) sub("\\.cu$", "", src)
+
+#' Auto id for a corpus exe with no spec entry. e.g.
+#' "kernels/attention/cross_attention/bench_v2" ->
+#' "attention_cross_attention_bench_v2".
+auto_id <- function(exe) gsub("[/]", "_", sub("^kernels/", "", exe))
+
+#' Merge the discovered corpus with the YAML spec.
+#'
+#' Every spec config becomes a config record (spec_source="known"). Every
+#' corpus exe NOT referenced by any spec config becomes one default config
+#' (spec_source="default", args=default_args, generic parse). Result: EVERY
+#' exe is covered at least once, nothing dropped.
+#'
+#' @return list of config records (id, exe, src, args, match, section,
+#'   value_label, unit, valid_when, n_samples, timeout, run, measurable,
+#'   spec_source, in_corpus, notes).
+merge_spec <- function(corpus_src, spec_kernels, default_args) {
+  corpus_exes <- vapply(corpus_src, exe_for_src, character(1))
+  src_by_exe  <- stats::setNames(corpus_src, corpus_exes)
+
+  mk <- function(k, spec_source) {
+    exe <- k$exe
+    in_corpus <- exe %in% corpus_exes
+    list(
+      id          = k$id %||% auto_id(exe),
+      exe         = exe,
+      src         = if (in_corpus) src_by_exe[[exe]] else paste0(exe, ".cu"),
+      args        = as.character(unlist(k$args %||% list())),
+      match       = k$match %||% NULL,
+      section     = k$section %||% NULL,
+      value_label = k$value_label %||% NULL,
+      unit        = k$unit %||% NA_character_,
+      valid_when  = k$valid_when %||% NULL,
+      n_samples   = k$n_samples %||% NULL,
+      timeout     = k$timeout %||% NULL,
+      run         = if (identical(k$run, FALSE)) FALSE else TRUE,
+      measurable  = if (identical(k$measurable, FALSE)) FALSE else TRUE,
+      verified    = isTRUE(k$verified),
+      spec_source = spec_source,
+      in_corpus   = in_corpus,
+      notes       = k$note %||% k$notes %||% ""
+    )
+  }
+
+  configs <- list()
+  specced_exes <- character(0)
+  for (k in spec_kernels %||% list()) {
+    specced_exes <- c(specced_exes, k$exe)
+    configs[[length(configs) + 1L]] <- mk(k, "known")
+  }
+
+  uncovered <- setdiff(corpus_exes, unique(specced_exes))
+  for (exe in sort(uncovered)) {
+    configs[[length(configs) + 1L]] <- mk(list(
+      exe = exe, args = as.list(default_args),
+      note = "no spec entry; default args + generic parse (invocation UNVERIFIED)"
+    ), "default")
+  }
+  configs
+}
+
+#' Status for a finished MEASURABLE config (not-built / skipped /
+#' non-measurable are decided by the caller). complete -> ok; some but
+#' not enough -> degraded; none -> failed.
+classify_status <- function(complete, n_valid_collected) {
+  if (isTRUE(complete)) "ok"
+  else if (n_valid_collected > 0L) "degraded"
+  else "failed"
+}
+
+#' Canonical bucket for a per-sample reject reason (for the histogram).
+reason_bucket <- function(reason) {
+  if (is.null(reason) || length(reason) == 0L || is.na(reason)) return("unknown")
+  if      (startsWith(reason, "crash"))       "crash"
+  else if (startsWith(reason, "parse-fail"))  "parse-fail"
+  else if (startsWith(reason, "unfair"))      "unfair"
+  else if (startsWith(reason, "no-gpu-meta")) "no-gpu-meta"
+  else if (startsWith(reason, "clock"))       "clock-band"
+  else if (startsWith(reason, "error"))       "error"
+  else                                        "other"
+}
+
+#' Histogram of reject reasons -> named integer vector (counts by bucket).
+reject_histogram <- function(reasons) {
+  if (!length(reasons)) return(stats::setNames(integer(0), character(0)))
+  buckets <- vapply(reasons, reason_bucket, character(1))
+  tb <- table(buckets)
+  stats::setNames(as.integer(tb), names(tb))
+}
+
+#' Short "top reason" string for a degraded/failed config.
+top_reject <- function(hist) {
+  if (!length(hist)) return("")
+  ord <- order(hist, decreasing = TRUE)
+  paste(sprintf("%s:%d", names(hist)[ord], hist[ord]), collapse = " ")
+}
+
+#' Pick the reported unit: spec unit wins (authoritative, e.g. GB/s, which
+#' parse_throughput would mislabel GFLOPS), else the parsed unit.
+pick_unit <- function(spec_unit, parsed_units) {
+  if (!is.null(spec_unit) && length(spec_unit) && !is.na(spec_unit) &&
+      nzchar(spec_unit)) return(spec_unit)
+  u <- parsed_units[!is.na(parsed_units)]
+  if (length(u)) u[[1]] else NA_character_
+}
+
+#' Build the per-config summary from valid samples + every attempt. Pure:
+#' the test drives it with synthetic input.
+summarise_config <- function(cfg, valid_tputs, valid_mss, valid_units,
+                             reject_reasons, n_attempts, complete,
+                             attempts = list()) {
+  n_valid <- length(valid_tputs)
+  status  <- classify_status(complete, n_valid)
+  hist    <- reject_histogram(reject_reasons)
+  med     <- if (n_valid > 0L) report_median_metrics(valid_tputs, valid_mss)
+             else NULL
+  list(
+    id                  = cfg$id,
+    exe                 = cfg$exe,
+    src                 = cfg$src,
+    args                = cfg$args,
+    spec_source         = cfg$spec_source,
+    invocation_verified = identical(cfg$spec_source, "known"),
+    measurable          = isTRUE(cfg$measurable),
+    verified            = isTRUE(cfg$verified),
+    status              = status,
+    n_valid             = n_valid,
+    n_attempts          = as.integer(n_attempts),
+    median_throughput   = med$median_throughput %||% NA_real_,
+    median_ms           = med$median_ms %||% NA_real_,
+    tput_lo             = med$tput_lo %||% NA_real_,
+    tput_hi             = med$tput_hi %||% NA_real_,
+    unit                = pick_unit(cfg$unit, valid_units),
+    reject_buckets      = as.list(hist),
+    top_reject          = top_reject(hist),
+    notes               = cfg$notes,
+    attempts            = attempts
+  )
+}
+
+#' A config skeleton summary for the non-running cases (not-built /
+#' skipped / non-measurable), so the report shape is uniform.
+skeleton_summary <- function(cfg, status, n_valid, n_attempts, note,
+                             attempts = list(), median = NA_real_,
+                             median_ms = NA_real_, unit = NA_character_) {
+  list(
+    id = cfg$id, exe = cfg$exe, src = cfg$src, args = cfg$args,
+    spec_source = cfg$spec_source,
+    invocation_verified = identical(cfg$spec_source, "known"),
+    measurable = isTRUE(cfg$measurable),
+    verified = isTRUE(cfg$verified),
+    status = status, n_valid = as.integer(n_valid),
+    n_attempts = as.integer(n_attempts),
+    median_throughput = median, median_ms = median_ms,
+    tput_lo = NA_real_, tput_hi = NA_real_,
+    unit = pick_unit(cfg$unit, character(0)),
+    reject_buckets = list(), top_reject = note,
+    notes = cfg$notes, attempts = attempts
+  )
+}
+
+#' Render the human-readable summary.md. Pure string builder -- the test
+#' asserts the measurable / non-measurable / default-args buckets stay
+#' separate (the advisor invariant: a default-args or non-measurable parse
+#' miss must never read as a real kernel failure).
+render_summary_md <- function(run_meta, summaries) {
+  fmt <- function(x) if (is.na(x)) "-" else format(round(x, 1), big.mark = "", nsmall = 1)
+  row <- function(s) {
+    spread <- if (is.na(s$tput_lo)) "-" else sprintf("%s-%s", fmt(s$tput_lo), fmt(s$tput_hi))
+    ver <- if (isTRUE(s$verified)) "verified" else if (isTRUE(s$measurable)) "infer" else "-"
+    sprintf("| %s | `%s` | %s | %s | %d/%d | %s | %s | %s | %s |",
+            s$id, paste(s$args, collapse = " "), s$status, ver,
+            s$n_valid, s$n_attempts, fmt(s$median_throughput),
+            if (is.na(s$unit)) "" else s$unit, spread, s$top_reject)
+  }
+  hdr <- paste0(
+    "| id | args | status | spec | valid/try | median | unit | spread | note |\n",
+    "|----|------|--------|------|-----------|--------|------|--------|------|")
+  counts <- function(ss) {
+    st <- vapply(ss, function(s) s$status, character(1))
+    paste(sprintf("%s=%d", names(table(st)), as.integer(table(st))), collapse = " ")
+  }
+  is_measurable_known <- function(s) identical(s$spec_source, "known") && isTRUE(s$measurable)
+  is_nonmeasurable    <- function(s) identical(s$spec_source, "known") && !isTRUE(s$measurable)
+  is_default          <- function(s) identical(s$spec_source, "default")
+
+  perf    <- Filter(is_measurable_known, summaries)
+  nonmeas <- Filter(is_nonmeasurable,    summaries)
+  deflt   <- Filter(is_default,          summaries)
+
+  out <- c(
+    "# bench-all full-corpus report",
+    "",
+    sprintf("- Generated: %s", run_meta$ts_utc),
+    sprintf("- Commit: %s%s", substr(run_meta$git_head %||% "?", 1, 12),
+            if (isTRUE(run_meta$git_dirty)) " (dirty)" else ""),
+    sprintf("- Host: %s", run_meta$host %||% "?"),
+    sprintf("- GPU: %s (driver %s, %s, %s)", run_meta$gpu_name %||% "?",
+            run_meta$driver_version %||% "?", run_meta$sm_arch %||% "?",
+            run_meta$nvcc %||% "?"),
+    sprintf("- GPU mode: %s   |   clock: %s", run_meta$gpu_mode %||% "?",
+            run_meta$clock_lock %||% "native"),
+    "",
+    "Native-boost run. Power-bound kernels (e.g. igemm_sparse 4096) throttle",
+    "here and land `degraded`/`failed` -- expected and recorded, not hidden.",
+    "For their fair number use a host-side clock lock",
+    "(scripts/probe/run_locked_eval.ps1); for clock/power context see",
+    "scripts/probe/probe_gpu_power.R.",
+    "",
+    "## Measurable corpus (single-number perf)",
+    "",
+    "`spec=verified`: args + parse hint confirmed by a recorded baseline /",
+    "sweep number. `spec=infer`: hint read from the bench source -- this run",
+    "confirms it. A `failed`/`parse-fail` on an `infer` row is most likely a",
+    "spec-hint bug to fix in bench_all.yml, NOT a real kernel failure.",
+    sprintf("_%s_", counts(perf)), "", hdr,
+    vapply(perf, row, character(1)), "",
+    "## Non-measurable / skipped (documented, NOT failures)",
+    "",
+    "A/B sweep tables, ms-only composed pipelines, correctness harnesses,",
+    "and benches needing external data / unavailable libs. `non-measurable`",
+    "means it ran but emits no single number; `skipped` means it was not run",
+    "(reason in the note). Neither is a kernel failure.",
+    sprintf("_%s_", counts(nonmeas)), "", hdr,
+    vapply(nonmeas, row, character(1)), "",
+    "## Discovered without a spec (default args -- invocation UNVERIFIED)",
+    "",
+    "Empty unless a new bench was added to the corpus without a",
+    "`bench_all.yml` entry. A `failed` here most likely means the default",
+    "args were wrong, NOT a real kernel failure -- add a spec entry.",
+    sprintf("_%s_", if (length(deflt)) counts(deflt) else "none"), "", hdr,
+    vapply(deflt, row, character(1)), ""
+  )
+  paste(out, collapse = "\n")
+}
+
+# ======================================================================
+# GPU glue (not unit-tested; needs a real GPU + built corpus).
+# ======================================================================
+
+git_head <- function() {
+  res <- tryCatch(system2("git", c("rev-parse", "HEAD"), stdout = TRUE, stderr = FALSE),
+                  error = function(e) NA_character_)
+  if (length(res) == 0L) NA_character_ else res[[1]]
+}
+git_dirty <- function() {
+  res <- tryCatch(system2("git", c("status", "--porcelain"), stdout = TRUE, stderr = FALSE),
+                  error = function(e) character(0))
+  length(res) > 0L
+}
+nvcc_release <- function() {
+  tryCatch({
+    r <- system2("nvcc", "--version", stdout = TRUE, stderr = FALSE)
+    m <- regmatches(paste(r, collapse = " "),
+                    regexec("release\\s+([0-9.]+)", paste(r, collapse = " "), perl = TRUE))[[1]]
+    if (length(m) >= 2) paste0("CUDA ", m[2]) else NA_character_
+  }, error = function(e) NA_character_)
+}
+smi_static <- function(field) {
+  tryCatch({
+    r <- system2("nvidia-smi", c(sprintf("--query-gpu=%s", field),
+                                 "--format=csv,noheader,nounits"),
+                 stdout = TRUE, stderr = FALSE)
+    trimws(r[[1]])
+  }, error = function(e) NA_character_)
+}
+
+build_run_meta <- function() {
+  list(
+    ts_utc         = format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"),
+    git_head       = git_head(),
+    git_dirty      = git_dirty(),
+    host           = unname(Sys.info()[["nodename"]]),
+    os             = tryCatch(readLines("/proc/version", n = 1, warn = FALSE),
+                              error = function(e) NA_character_),
+    nvcc           = nvcc_release(),
+    driver_version = smi_static("driver_version"),
+    gpu_name       = smi_static("name"),
+    gpu_memory_mb  = smi_static("memory.total"),
+    gpu_mode       = tolower(Sys.getenv("BARE_METAL_GPU_MODE", unset = "unknown")),
+    clock_lock     = "native",
+    sm_arch        = "sm_86"
+  )
+}
+
+#' Build a per-attempt JSONL row (also kept in results.json attempts[]).
+attempt_row <- function(cfg, s, ok, reason, attempt, run_id, gh) {
+  post <- s$r$post
+  list(
+    run_id = run_id, ts_utc = format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"),
+    git_head = gh, cell_id = cfg$id, exe = cfg$exe, spec_source = cfg$spec_source,
+    args_str = paste(cfg$args, collapse = ","), attempt = as.integer(attempt),
+    ms = s$parsed$ms, throughput = s$parsed$throughput, unit = s$parsed$unit,
+    clock_sm_mhz = as.integer((post$gpu$clock_sm %||% NA_integer_)),
+    power_w = as.numeric((post$gpu$power_w %||% NA_real_)),
+    temp_c = as.numeric((post$gpu$temp_c %||% NA_real_)),
+    throttle = paste(setdiff(post$gpu$throttle %||% character(0), "GpuIdle"), collapse = ","),
+    gpu_mode = post$host$gpu_mode %||% NA_character_,
+    valid = isTRUE(ok), reject_reason = reason %||% NA_character_, rc = s$r$rc
+  )
+}
+
+one_run <- function(exe_abs, cfg, timeout) {
+  r <- run_bench(exe_abs, cfg$args, timeout = timeout)
+  parsed <- parse_throughput(r$out, match = cfg$match, section = cfg$section,
+                             value_label = cfg$value_label, pick = "first")
+  list(r = r, parsed = parsed)
+}
+
+#' Measure one config: dispatch on run / measurable, never throw.
+measure_config <- function(cfg, opts, jsonl_path, run_id, gh) {
+  if (identical(cfg$run, FALSE))
+    return(skeleton_summary(cfg, "skipped", 0L, 0L,
+                            cfg$notes %||% "run: false in spec"))
+
+  exe_abs <- file.path(REPO_ROOT, cfg$exe)
+  if (!file.exists(exe_abs))
+    return(skeleton_summary(cfg, "not-built", 0L, 0L, "exe not built (try: make all)"))
+  exe_abs <- normalizePath(exe_abs, mustWork = TRUE)
+
+  prev_wd <- getwd(); setwd(dirname(exe_abs)); on.exit(setwd(prev_wd), add = TRUE)
+  timeout <- as.integer(cfg$timeout %||% opts$timeout)
+
+  # Non-measurable: run ONCE to confirm it executes. A parse miss is
+  # EXPECTED (no single number) -> status non-measurable; a non-zero exit
+  # is a real run failure -> status failed.
+  if (identical(cfg$measurable, FALSE)) {
+    # Non-measurable benches often run a long internal sweep (many shapes).
+    # Give the single confirming run a more generous timeout so a slow-but-
+    # fine sweep is not killed and mislabelled `failed`.
+    nm_timeout <- as.integer(cfg$timeout %||% max(opts$timeout, 300L))
+    s <- one_run(exe_abs, cfg, nm_timeout)
+    if (identical(s$r$rc, 130L)) { message("SIGINT -- cancelling"); quit(save = "no", status = 130L) }
+    ok <- identical(s$r$rc, 0L)
+    row <- attempt_row(cfg, s, ok, if (ok) "non-measurable" else sprintf("crash(exit=%d)", s$r$rc),
+                       1L, run_id, gh)
+    append_jsonl_row(jsonl_path, row)
+    note <- if (ok) (cfg$notes %||% "ran; no single-number metric")
+            else sprintf("ran but exited %d", s$r$rc)
+    return(skeleton_summary(cfg, if (ok) "non-measurable" else "failed",
+                            0L, 1L, note, attempts = list(row)))
+  }
+
+  vw      <- cfg$valid_when %||% DEFAULT_VALID_WHEN
+  n_valid <- as.integer(cfg$n_samples %||% opts$min_valid)
+
+  # `attempts` accumulates every attempt row. on_sample's `attempts[[..]] <<- `
+  # binds THIS frame because collect_valid_samples invokes on_sample
+  # synchronously, inline, before measure_config returns (bench_measure.R). If
+  # that ever becomes async/deferred the super-assignment would break -- keep it
+  # synchronous, or pass `attempts` through explicitly.
+  attempts <- list()
+
+  on_sample <- function(attempt, ok, s, reason) {
+    if (identical(s$r$rc, 130L)) { message("SIGINT -- cancelling"); quit(save = "no", status = 130L) }
+    row <- attempt_row(cfg, s, ok, reason, attempt, run_id, gh)
+    append_jsonl_row(jsonl_path, row)
+    attempts[[length(attempts) + 1L]] <<- row
+    cat(sprintf("    %-26s try %2d  %s %s  %s\n", cfg$id, attempt,
+                if (is.na(s$parsed$throughput)) "NA" else format(round(s$parsed$throughput, 0), big.mark = ""),
+                if (is.na(s$parsed$unit)) "" else s$parsed$unit,
+                if (isTRUE(ok)) "OK" else sprintf("REJECT(%s)", reason)))
+    # Adaptive cooldown: longer after an unfair/throttle reject so the GPU
+    # sheds heat / leaves the power cap before the next attempt.
+    cool <- opts$cooldown
+    if (!isTRUE(ok) && !is.na(reason) && startsWith(reason, "unfair"))
+      cool <- cool * opts$cooldown_throttle_mult
+    if (cool > 0) Sys.sleep(cool)
+  }
+
+  res <- collect_valid_samples(
+    sample_fn = function() one_run(exe_abs, cfg, timeout),
+    validate_fn = function(s) validate_sample(s$r$rc, s$parsed$throughput,
+                                              s$r$pre, s$r$post, valid_when = vw),
+    n_valid = n_valid, max_attempts = opts$max_attempts, on_sample = on_sample)
+
+  tputs <- vapply(res$samples, function(s) s$parsed$throughput, numeric(1))
+  mss   <- vapply(res$samples, function(s) s$parsed$ms %||% NA_real_, numeric(1))
+  units <- vapply(res$samples, function(s) s$parsed$unit %||% NA_character_, character(1))
+  summarise_config(cfg, tputs, mss, units, res$rejected, res$attempts,
+                   res$complete, attempts = attempts)
+}
+
+# ----------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------
+parse_args <- function(argv) {
+  out <- list(spec = DEFAULT_SPEC, out_dir = NULL, min_valid = 5L,
+              max_attempts = 15L, cooldown = 2, cooldown_throttle_mult = 4,
+              timeout = 120L, only = NULL, default_args = character(0),
+              list_only = FALSE)
+  i <- 1
+  while (i <= length(argv)) {
+    a <- argv[i]
+    if      (a == "--spec")         { out$spec <- argv[i+1]; i <- i+2 }
+    else if (a == "--out-dir")      { out$out_dir <- argv[i+1]; i <- i+2 }
+    else if (a == "--min-valid")    { out$min_valid <- as.integer(argv[i+1]); i <- i+2 }
+    else if (a == "--max-attempts") { out$max_attempts <- as.integer(argv[i+1]); i <- i+2 }
+    else if (a == "--cooldown")     { out$cooldown <- as.numeric(argv[i+1]); i <- i+2 }
+    else if (a == "--timeout")      { out$timeout <- as.integer(argv[i+1]); i <- i+2 }
+    else if (a == "--only")         { out$only <- argv[i+1]; i <- i+2 }
+    else if (a == "--default-args") { out$default_args <- strsplit(argv[i+1], ",", fixed=TRUE)[[1]]; i <- i+2 }
+    else if (a %in% c("--list", "--dry-run")) { out$list_only <- TRUE; i <- i+1 }
+    else if (a %in% c("-h", "--help")) {
+      cat("Usage: bench_all.R [--spec F] [--out-dir D] [--min-valid N]",
+          "[--max-attempts N]\n",
+          "                   [--cooldown S] [--timeout S] [--only ID]",
+          "[--default-args a,b,c] [--list]\n",
+          "  --list  print the planned corpus (spec_source per exe) and exit (no GPU)\n",
+          sep = "")
+      quit(status = 0)
+    }
+    else stop("unknown arg: ", a)
+  }
+  out
+}
+
+load_spec_kernels <- function(spec_path) {
+  if (!file.exists(spec_path)) {
+    cat(sprintf("WARN: spec not found (%s); every bench runs default-args.\n", spec_path))
+    return(list())
+  }
+  (yaml::read_yaml(spec_path))$kernels %||% list()
+}
+
+main <- function() {
+  opts <- parse_args(commandArgs(trailingOnly = TRUE))
+
+  corpus  <- discover_corpus(REPO_ROOT)
+  spec_k  <- load_spec_kernels(opts$spec)
+  configs <- merge_spec(corpus, spec_k, opts$default_args)
+  if (!is.null(opts$only))
+    configs <- Filter(function(c) identical(c$id, opts$only), configs)
+  if (!length(configs)) { cat("No configs to run.\n"); quit(status = 1) }
+
+  n_known   <- sum(vapply(configs, function(c) c$spec_source == "known", logical(1)))
+  n_default <- length(configs) - n_known
+  n_meas    <- sum(vapply(configs, function(c) isTRUE(c$measurable) && !identical(c$run, FALSE), logical(1)))
+
+  cat(strrep("=", 72), "\n", sep = "")
+  cat("  bench-all -- full-corpus run (skip nothing, record everything)\n")
+  cat(sprintf("  corpus %d exes | configs %d (known %d, default %d) | measurable %d\n",
+              length(corpus), length(configs), n_known, n_default, n_meas))
+  cat(sprintf("  min-valid %d | max-attempts %d | cooldown %.1fs\n",
+              opts$min_valid, opts$max_attempts, opts$cooldown))
+  cat(strrep("=", 72), "\n", sep = "")
+
+  if (opts$list_only) {
+    for (c in configs) {
+      tag <- if (identical(c$run, FALSE)) "skip" else if (!isTRUE(c$measurable)) "nomeas" else "perf"
+      cat(sprintf("  [%-7s %-6s] %-30s  %s  args=[%s]\n",
+                  c$spec_source, tag, c$id, c$exe, paste(c$args, collapse = " ")))
+    }
+    cat(sprintf("\n%d configs planned (%d known, %d default, %d measurable).\n",
+                length(configs), n_known, n_default, n_meas))
+    quit(status = 0)
+  }
+
+  run_id  <- format(Sys.time(), "%Y%m%dT%H%M%S")
+  out_dir <- opts$out_dir %||% file.path(REPO_ROOT, "results", "bench_all", run_id)
+  dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+  jsonl_path <- file.path(out_dir, "samples.jsonl")
+  results_path <- file.path(out_dir, "results.json")
+  summary_path <- file.path(out_dir, "summary.md")
+
+  run_meta <- build_run_meta()
+  gh <- run_meta$git_head
+  .gs <- capture_gpu_state()
+  if (!is.null(.gs)) {
+    cat(sprintf("  GPU state: %s\n", summarise_meta(.gs, .gs)))
+    cat(strrep("=", 72), "\n", sep = "")
+  } else {
+    cat("  WARNING: no GPU metadata (nvidia-smi absent) -- runs unguarded.\n")
+  }
+
+  summaries <- list()
+  for (cfg in configs) {
+    cat(sprintf("\n[%s] %s  (args=[%s], %s)\n", cfg$id, cfg$exe,
+                paste(cfg$args, collapse = " "), cfg$spec_source))
+    s <- tryCatch(measure_config(cfg, opts, jsonl_path, run_id, gh),
+      error = function(e) {
+        cat(sprintf("    ERROR (recorded, corpus continues): %s\n", conditionMessage(e)))
+        skeleton_summary(cfg, "failed", 0L, 0L,
+                         sprintf("error: %s", conditionMessage(e)))
+      })
+    summaries[[length(summaries) + 1L]] <- s
+    cat(sprintf("    => %s  (%d/%d valid)\n", s$status, s$n_valid, s$n_attempts))
+  }
+
+  writeLines(jsonlite::toJSON(list(run_meta = run_meta, configs = summaries),
+                              auto_unbox = TRUE, na = "null", null = "null", pretty = TRUE),
+             results_path)
+  writeLines(render_summary_md(run_meta, summaries), summary_path)
+
+  st <- vapply(summaries, function(s) s$status, character(1))
+  cat("\n", strrep("=", 72), "\n", sep = "")
+  cat(sprintf("  Done. %s\n",
+              paste(sprintf("%s=%d", names(table(st)), as.integer(table(st))), collapse = " ")))
+  cat(sprintf("  results.json : %s\n", results_path))
+  cat(sprintf("  summary.md   : %s\n", summary_path))
+  cat(sprintf("  samples.jsonl: %s\n", jsonl_path))
+  cat(strrep("=", 72), "\n", sep = "")
+
+  # bench-all is a data-collection pass, not a gate: exit 0 even with
+  # failures (they are recorded in the report; the reader is the judge).
+  quit(status = 0)
+}
+
+if (sys.nframe() == 0L) {
+  tryCatch(main(),
+    interrupt = function(c) { message("Interrupted by user (SIGINT)"); quit(save = "no", status = 130) })
+}

--- a/scripts/bench/bench_all.yml
+++ b/scripts/bench/bench_all.yml
@@ -1,0 +1,369 @@
+# bench_all.yml -- declarative corpus spec for the full "run everything"
+# pass (#124). Consumed by scripts/bench/bench_all.R.
+#
+# It enumerates EVERY bench executable in $(BENCH_EXES) with its exact
+# invocation contract, so the runner never guesses args. (A corpus exe
+# with no entry here is still run, with --default-args + a generic parse,
+# flagged spec_source="default" and reported separately.)
+#
+# Per-kernel fields:
+#   id          unique slug (appears in the report + samples.jsonl).
+#   exe         repo-relative path to the bench binary.
+#   args        positional args; [] = use the bench's own internal defaults.
+#   match       fixed substring picking this kernel's output line
+#               (required when the bench prints several variants).
+#   section     fixed substring of a `===`/`---` section header; the parser
+#               only looks at lines after it. Omit unless `match` is
+#               ambiguous across sections (over-constraining risks a miss).
+#   value_label text immediately AFTER the throughput number on the line
+#               (e.g. "dense-equiv GFLOPS", "GB/s"); needed when the line
+#               carries several numbers, so the right column is taken.
+#   unit        authoritative unit for the report (set for GB/s benches --
+#               parse_throughput would otherwise mislabel them GFLOPS).
+#   measurable  false -> the bench emits no single parseable number (A/B
+#               sweep table, ms-only composed pipeline, correctness
+#               harness). It is run ONCE to confirm it executes; a parse
+#               miss is EXPECTED (status non-measurable), never `failed`.
+#   run         false -> cannot run meaningfully here (stub library, needs
+#               external data). Documented `skipped`, not run.
+#   verified    true  -> args + parse hint are confirmed by a recorded
+#               number (data/baselines.json or scripts/probe/grid_sweep.yml
+#               sweep). false/absent -> inferred from the bench source; a
+#               first GPU bench-all run confirms it. A parse-fail on an
+#               unverified entry is a HINT bug to fix here, NOT a real
+#               kernel failure -- do not read it as one.
+#   note        free text (carried into the report).
+#
+# Seeds: the 5 baselined kernels (data/baselines.json) + grid_sweep.yml
+# are reproduced verbatim and marked verified: true. The rest are mapped
+# from each bench's argv parsing + throughput printf (mapping pass #124).
+
+kernels:
+  # ---------------- GEMM: hgemm ----------------
+  - id: hgemm_16warp_2048
+    exe: kernels/gemm/hgemm/bench
+    args: [2048, 2048, 2048]
+    match: "hgemm_16warp (128x128 2blk/SM)"
+    verified: true
+    note: "baselines.json 31789 GFLOPS"
+
+  - id: hgemm_16warp_4096
+    exe: kernels/gemm/hgemm/bench
+    args: [4096, 4096, 4096]
+    match: "hgemm_16warp (128x128 2blk/SM)"
+    verified: true
+    note: "baselines.json 30397 GFLOPS"
+
+  - id: hgemm_aligned_4096
+    exe: kernels/gemm/hgemm/bench_aligned
+    args: []
+    match: "hgemm_16warp (baseline)"
+    note: "A/B vs aligned variant; default 4096^3 (M%128,N%128,K%32)"
+
+  - id: hgemm_epi_pad_4096
+    exe: kernels/gemm/hgemm/bench_epi_pad
+    args: []
+    match: "hgemm_16warp_epi (baseline)"
+    note: "A/B vs padded epilogue; default 4096^3"
+
+  - id: hgemm_dispatch
+    exe: kernels/gemm/hgemm/bench_dispatch
+    measurable: false
+    note: "dispatch-heuristic validation harness; ms-only comparison table, no GFLOPS"
+
+  - id: hgemm_persistent
+    exe: kernels/gemm/hgemm/bench_persistent
+    measurable: false
+    note: "A/B sweep table over 6 shapes; GFLOPS in columns, no single-number line"
+
+  - id: hgemm_splitk
+    exe: kernels/gemm/hgemm/bench_splitk
+    measurable: false
+    note: "A/B sweep table over 7 shapes x k-split; no single-number line"
+
+  # ---------------- GEMM: hgemm_sparse ----------------
+  - id: hgemm_sparse_tiled
+    exe: kernels/gemm/hgemm_sparse/bench
+    args: [2048, 2048, 2048]
+    measurable: false
+    note: "tiled-table output (ms/eff/dense-eq columns header-labeled, not on data row); perf section needs M>=512"
+
+  # ---------------- GEMM: sgemm ----------------
+  - id: sgemm_register_blocked
+    exe: kernels/gemm/sgemm/bench
+    args: [1024, 1024, 1024]
+    match: "register_blocked"
+    note: "FP32; canonical variant register_blocked"
+
+  # ---------------- GEMM: igemm ----------------
+  - id: igemm_cpasync_4096
+    exe: kernels/gemm/igemm/bench
+    args: [4096, 4096, 4096]
+    match: "igemm_cpasync"
+    value_label: "TOPS"
+    verified: true
+    note: "baselines.json 20227 TOPS (cp.async dbuf)"
+
+  - id: igemm_sparse_2048
+    exe: kernels/gemm/igemm/bench_sparse
+    args: [2048, 2048, 2048]
+    match: "igemm_sparse_tiled"
+    value_label: "dense-equiv GFLOPS"
+    verified: true
+    note: "baselines.json 36892 dense-equiv GFLOPS"
+
+  - id: igemm_sparse_4096
+    exe: kernels/gemm/igemm/bench_sparse
+    args: [4096, 4096, 4096]
+    match: "igemm_sparse_tiled"
+    value_label: "dense-equiv GFLOPS"
+    verified: true
+    note: "power-bound: throttles at native boost (expected degraded/failed here). Fair number is 50497 @ -lgc 1605 -- use run_locked_eval.ps1"
+
+  - id: igemm_sparse_persistent_512
+    exe: kernels/gemm/igemm/bench_persistent
+    args: [512, 512, 512]
+    match: "igemm_sparse_tiled_persistent"
+    value_label: "eff GFLOPS"
+    note: "persistent-grid sparse INT8; eff GFLOPS (2:4)"
+
+  # ---------------- attention: flash_attention ----------------
+  - id: flash_attn_multihead
+    exe: kernels/attention/flash_attention/bench
+    args: []
+    match: "flash_attn_multihead"
+    value_label: "GFLOPS"
+    note: "default seq=512 b=1 h=1; multi-head perf line"
+
+  - id: flash_attn_bc128
+    exe: kernels/attention/flash_attention/bench_bc128
+    args: []
+    match: "Bc=128:"
+    value_label: "GFLOPS"
+    note: "internal sweep; Bc=128 line, first config"
+
+  - id: flash_attn_br16
+    exe: kernels/attention/flash_attention/bench_br16
+    args: []
+    match: "flash_attn_br16  (FP16, HMMA)"
+    value_label: "GB/s"
+    unit: "GB/s"
+    note: "default 1024/8/8; br16 HMMA bandwidth line"
+
+  - id: flash_attn_br16_regpv_1024
+    exe: kernels/attention/flash_attention/bench_br16_regpv
+    args: [1024, 8, 8]
+    match: "flash_attn_br16_regpv"
+    verified: true
+    note: "baselines.json 7152 GFLOPS (seq=1024 b=8 h=8)"
+
+  - id: flash_attn_fused
+    exe: kernels/attention/flash_attention/bench_fused
+    args: []
+    match: "flash_attn_fused"
+    value_label: "GFLOPS"
+    note: "default 1024/8/8; fused BSHD perf line"
+
+  - id: flash_attn_split_q
+    exe: kernels/attention/flash_attention/bench_split_q
+    args: [1024, 8, 8]
+    match: "br16 baseline"
+    value_label: "GFLOPS"
+    note: "split-Q vs br16 baseline; baseline reference line"
+
+  - id: flash_attn_pipeline
+    exe: kernels/attention/flash_attention/bench_pipeline
+    args: []
+    match: "Baseline:"
+    value_label: "GFLOPS"
+    note: "baseline vs cp.async pipelined; first config baseline line"
+
+  - id: flash_attn_wmma
+    exe: kernels/attention/flash_attention/bench_wmma
+    args: [1024, 8, 8]
+    match: "flash_attn_4warp"
+    value_label: "GB/s"
+    unit: "GB/s"
+    note: "1-warp vs WMMA 4-warp; bandwidth (GB/s), not GFLOPS"
+
+  - id: flash_attn_br16_regpv_pad
+    exe: kernels/attention/flash_attention/bench_br16_regpv_pad
+    measurable: false
+    note: "8-variant smem-padding sweep table; no single-number line"
+
+  - id: flash_attn_persistent
+    exe: kernels/attention/flash_attention/bench_persistent
+    measurable: false
+    note: "persistent-grid sweep table (3 seq); columns, no single-number line"
+
+  - id: flash_attn_v2_baseline_pad
+    exe: kernels/attention/flash_attention/bench_v2_baseline_pad
+    measurable: false
+    note: "v2 unpadded-vs-padded sweep table; no single-number line"
+
+  - id: flash_attn_v2_persistent_pad
+    exe: kernels/attention/flash_attention/bench_v2_persistent_pad
+    measurable: false
+    note: "v2 persistent unpadded-vs-padded sweep table; no single-number line"
+
+  - id: flash_attn_v2_pipeline_pad
+    exe: kernels/attention/flash_attention/bench_v2_pipeline_pad
+    measurable: false
+    note: "v2 pipeline 3-padding sweep table; no single-number line"
+
+  - id: flash_attn_v2_variants
+    exe: kernels/attention/flash_attention/bench_v2_variants
+    measurable: false
+    note: "v2 baseline|pipeline|persistent comparison table; no single-number line"
+
+  # ---------------- attention: cross_attention ----------------
+  - id: cross_attn
+    exe: kernels/attention/cross_attention/bench
+    measurable: false
+    note: "ms and GFLOPS printed on separate lines; parser needs both on one line"
+
+  - id: cross_attn_dispatch
+    exe: kernels/attention/cross_attention/bench_dispatch
+    measurable: false
+    note: "regime-dispatch validation harness; correctness checks, no throughput"
+
+  - id: cross_attn_pipelined
+    exe: kernels/attention/cross_attention/bench_pipelined
+    args: []
+    match: "Baseline:"
+    value_label: "GFLOPS"
+    note: "baseline vs pipelined, 5 hardcoded configs; first baseline line. Long runtime"
+
+  - id: cross_attn_v2
+    exe: kernels/attention/cross_attention/bench_v2
+    measurable: false
+    note: "3-variant comparison table (smem/regs/blocks/ms/GFLOPS columns); no single-number line"
+
+  # ---------------- composition ----------------
+  - id: attention_layer
+    exe: kernels/composition/attention_layer/bench
+    measurable: false
+    note: "composed 11-step attention layer; ms-only relative comparison, no throughput metric"
+
+  # ---------------- convolution: conv2d ----------------
+  - id: conv2d_nhwc
+    exe: kernels/convolution/conv2d/bench
+    args: []
+    match: "conv2d_nhwc (3×3)"
+    value_label: "GFLOPS"
+    note: "default N1 64x64 Cin=Cout=64; 3x3 NHWC primary kernel"
+
+  - id: conv2d_implicit_gemm
+    exe: kernels/convolution/conv2d/bench_implicit_gemm
+    args: []
+    match: "Implicit (single kern)"
+    section: "SD 64"
+    verified: true
+    note: "baselines.json 7150 GFLOPS (SD 64x64 Cin=Cout=320)"
+
+  - id: conv2d_im2col
+    exe: kernels/convolution/conv2d/bench_im2col
+    measurable: false
+    note: "label-before-value output ('GFLOPS: N'); parser expects 'N GFLOPS'"
+
+  - id: conv2d_implicit_v2
+    exe: kernels/convolution/conv2d/bench_implicit_v2
+    measurable: false
+    note: "8-shape v1-vs-v2 comparison table; no single-number line"
+
+  # ---------------- convolution: resblock ----------------
+  - id: resblock
+    exe: kernels/convolution/resblock/bench
+    args: []
+    match: "Full ResNet Block"
+    value_label: "GFLOPS"
+    note: "default N1 C64 32x32 G8; full block (5 kernels), standard conv2d"
+
+  - id: resblock_implicit
+    exe: kernels/convolution/resblock/bench_implicit
+    args: []
+    match: "Full ResNet Block"
+    value_label: "GFLOPS"
+    note: "implicit_gemm conv (Tensor Cores)"
+
+  - id: resblock_implicit_v2
+    exe: kernels/convolution/resblock/bench_implicit_v2
+    args: []
+    match: "Full ResNet Block"
+    value_label: "GFLOPS"
+    note: "implicit_gemm_v2 (16-warp 128x128x32, FP16, cp.async)"
+
+  # ---------------- elementwise ----------------
+  - id: activations_relu
+    exe: kernels/elementwise/activations/bench
+    args: []
+    match: "relu_kernel"
+    value_label: "GB/s"
+    unit: "GB/s"
+    note: "memory-bound; relu canonical variant (bandwidth)"
+
+  - id: timestep_emb
+    exe: kernels/elementwise/timestep_emb/bench
+    args: []
+    match: "timestep_emb_batch"
+    value_label: "GB/s"
+    unit: "GB/s"
+    note: "default d_model=512 batch=1024; bandwidth"
+
+  # ---------------- reductions ----------------
+  - id: groupnorm_nhwc
+    exe: kernels/reductions/groupnorm/bench
+    args: []
+    match: "groupnorm NHWC"
+    value_label: "GB/s"
+    unit: "GB/s"
+    note: "default N4 C32 64x64 G8; NHWC bandwidth"
+
+  - id: layernorm_warp
+    exe: kernels/reductions/layernorm/bench
+    args: []
+    match: "layernorm_warp"
+    value_label: "GB/s"
+    unit: "GB/s"
+    note: "default 65536x32; warp variant bandwidth"
+
+  - id: softmax_warp
+    exe: kernels/reductions/softmax/bench
+    args: []
+    match: "softmax_warp"
+    value_label: "GB/s"
+    unit: "GB/s"
+    note: "default 65536x32; warp variant bandwidth"
+
+  # ---------------- memory_layout ----------------
+  - id: cymatic_gather
+    exe: kernels/memory_layout/cymatic/bench
+    run: false
+    note: "needs external data files perm.bin + traces.bin (generate via scripts/cymatic/*.R / gen_fa_traces.R); GB/s table, not run by default"
+
+  # ---------------- reference (cuBLAS / cuDNN / cuSPARSELt) ----------------
+  - id: ref_cublas_hgemm
+    exe: kernels/reference/cublas_hgemm/bench
+    args: [4096, 4096, 4096]
+    note: "cuBLAS FP16 GEMM reference; not-built if cuBLAS absent"
+
+  - id: ref_cublas_igemm
+    exe: kernels/reference/cublas_igemm/bench
+    args: [4096, 4096, 4096]
+    note: "cuBLAS INT8 GEMM reference (TOPS); not-built if cuBLAS absent"
+
+  - id: ref_cudnn_conv2d
+    exe: kernels/reference/cudnn_conv2d/bench
+    args: []
+    note: "cuDNN conv2d reference (default SD 64x64 Cin=Cout=320); not-built if cuDNN absent"
+
+  - id: ref_cudnn_sdpa
+    exe: kernels/reference/cudnn_sdpa/bench
+    run: false
+    note: "stub: cuDNN graph-based SDPA frontend unavailable on this system (prints to stderr, no measurement)"
+
+  - id: ref_cusparselt_igemm_sparse
+    exe: kernels/reference/cusparselt_igemm_sparse/bench
+    args: [4096, 4096, 4096]
+    value_label: "TOPS"
+    note: "cuSPARSELt 2:4 sparse INT8 reference (dense-equiv TOPS); not-built if cuSPARSELt absent. Data line is '... <ms> ms  <N> TOPS'; the words 'dense-equiv TOPS' appear only in the header, so match plain TOPS."

--- a/tests/bench_all/test_bench_all.R
+++ b/tests/bench_all/test_bench_all.R
@@ -1,0 +1,192 @@
+# tests/bench_all/test_bench_all.R
+#
+# GPU-free unit tests for scripts/bench/bench_all.R (issue #124). Drives
+# the pure functions (corpus discovery, spec merge, status classification,
+# summary aggregation, markdown render) with the real repo + synthetic
+# samples. The GPU glue (measure_config -> run_bench) needs a card and is
+# exercised by an actual `make bench-all`, not here -- mirroring the
+# project's GPU-free fixture-diff verification pattern.
+#
+# Run:
+#   Rscript -e 'testthat::test_file("tests/bench_all/test_bench_all.R", stop_on_failure=TRUE)'
+#   (or)  Rscript tests/bench_all/test_bench_all.R
+
+library(testthat)
+
+# Source bench_all.R for its functions. main() is guarded by
+# `if (sys.nframe() == 0L) main()`, so sourcing runs no benchmarks.
+.candidates <- c(
+  "scripts/bench/bench_all.R",
+  file.path(getwd(), "scripts", "bench", "bench_all.R"),
+  "/mnt/d/dev/p/bare-metal/scripts/bench/bench_all.R")
+.src <- NULL
+for (.p in .candidates) if (file.exists(.p)) { .src <- .p; break }
+if (is.null(.src)) stop("can't find bench_all.R")
+suppressMessages(source(.src))
+
+# ---- corpus discovery ------------------------------------------------
+test_that("discover_corpus finds the bench corpus and excludes non-benches", {
+  corpus <- discover_corpus(REPO_ROOT)
+  # Every entry is a bench.cu or a kernels/**/bench_*.cu.
+  expect_true(all(grepl("(^|/)bench\\.cu$|/bench_.*\\.cu$", corpus)))
+  # Known members present.
+  expect_true("kernels/gemm/hgemm/bench.cu" %in% corpus)
+  expect_true("kernels/gemm/igemm/bench_sparse.cu" %in% corpus)
+  expect_true("kernels/reference/cublas_hgemm/bench.cu" %in% corpus)
+  # Pruned / non-corpus files excluded.
+  expect_false(any(startsWith(corpus, "experiments/")))
+  expect_false(any(startsWith(corpus, "tools/")))
+  expect_false(any(grepl("^tests/", corpus)))          # tests/*.cu are not benches
+  # A real corpus (the repo currently ships 48).
+  expect_gte(length(corpus), 40L)
+})
+
+test_that("exe_for_src / auto_id", {
+  expect_equal(exe_for_src("kernels/gemm/hgemm/bench.cu"), "kernels/gemm/hgemm/bench")
+  expect_equal(auto_id("kernels/attention/cross_attention/bench_v2"),
+               "attention_cross_attention_bench_v2")
+})
+
+# ---- spec merge ------------------------------------------------------
+test_that("merge_spec marks known vs default and covers every exe once+", {
+  corpus <- c("a/bench.cu", "b/bench_x.cu", "c/bench.cu")
+  spec <- list(
+    list(id = "ka", exe = "a/bench", args = list(2048, 2048), match = "foo"),
+    list(id = "kb", exe = "b/bench_x", measurable = FALSE, note = "table"))
+  cfgs <- merge_spec(corpus, spec, default_args = c("512"))
+  src <- vapply(cfgs, function(c) c$spec_source, character(1))
+  ids <- vapply(cfgs, function(c) c$id, character(1))
+  # 2 known + 1 default (the uncovered c/bench).
+  expect_equal(sum(src == "known"), 2L)
+  expect_equal(sum(src == "default"), 1L)
+  defcfg <- cfgs[[which(src == "default")]]
+  expect_equal(defcfg$exe, "c/bench")
+  expect_equal(defcfg$args, "512")               # default args applied
+  expect_false(defcfg$measurable == FALSE)       # default is measurable
+  # known fields carried through.
+  ka <- cfgs[[which(ids == "ka")]]
+  expect_equal(ka$args, c("2048", "2048"))
+  expect_equal(ka$match, "foo")
+  kb <- cfgs[[which(ids == "kb")]]
+  expect_false(kb$measurable)
+})
+
+test_that("the shipped bench_all.yml covers the ENTIRE corpus (no default configs)", {
+  corpus  <- discover_corpus(REPO_ROOT)
+  spec_k  <- yaml::read_yaml(file.path(REPO_ROOT, "scripts", "bench", "bench_all.yml"))$kernels
+  cfgs    <- merge_spec(corpus, spec_k, default_args = character(0))
+  src     <- vapply(cfgs, function(c) c$spec_source, character(1))
+  defaulted <- vapply(cfgs[src == "default"], function(c) c$exe, character(1))
+  # A non-empty default set means a bench was added without a spec entry.
+  expect_equal(length(defaulted), 0L,
+               info = paste("un-specced exes:", paste(defaulted, collapse = ", ")))
+  # Unique ids.
+  ids <- vapply(cfgs, function(c) c$id, character(1))
+  expect_equal(anyDuplicated(ids), 0L)
+  # Every spec exe actually exists in the corpus.
+  spec_exes <- vapply(spec_k, function(k) k$exe, character(1))
+  expect_true(all(spec_exes %in% vapply(corpus, exe_for_src, character(1))),
+              info = "a spec exe is not in the discovered corpus")
+})
+
+# ---- status classification ------------------------------------------
+test_that("classify_status: ok / degraded / failed", {
+  expect_equal(classify_status(TRUE, 5L), "ok")
+  expect_equal(classify_status(FALSE, 2L), "degraded")
+  expect_equal(classify_status(FALSE, 0L), "failed")
+})
+
+test_that("reason buckets + histogram + top_reject", {
+  expect_equal(reason_bucket("crash(exit=1)"), "crash")
+  expect_equal(reason_bucket("parse-fail"), "parse-fail")
+  expect_equal(reason_bucket("unfair(SwPowerCap)"), "unfair")
+  expect_equal(reason_bucket(NA_character_), "unknown")
+  h <- reject_histogram(c("unfair(x)", "unfair(y)", "parse-fail"))
+  expect_equal(h[["unfair"]], 2L)
+  expect_equal(h[["parse-fail"]], 1L)
+  expect_true(startsWith(top_reject(h), "unfair:2"))
+})
+
+test_that("pick_unit: spec unit wins, else parsed, else NA", {
+  expect_equal(pick_unit("GB/s", c("GFLOPS")), "GB/s")        # spec authoritative
+  expect_equal(pick_unit(NA_character_, c("TOPS")), "TOPS")   # fall to parsed
+  expect_equal(pick_unit(NA_character_, character(0)), NA_character_)
+})
+
+# ---- summary aggregation --------------------------------------------
+test_that("summarise_config: median/spread/status/verified, attempts kept", {
+  cfg <- list(id = "k", exe = "e", src = "e.cu", args = c("2048"),
+              spec_source = "known", verified = TRUE, unit = NA_character_,
+              notes = "n")
+  atts <- list(list(attempt = 1L), list(attempt = 2L), list(attempt = 3L))
+  s <- summarise_config(cfg,
+                        valid_tputs = c(100, 110, 120),
+                        valid_mss   = c(1.0, 0.9, 0.8),
+                        valid_units = c("GFLOPS", "GFLOPS", "GFLOPS"),
+                        reject_reasons = c("unfair(x)"),
+                        n_attempts = 4L, complete = TRUE, attempts = atts)
+  expect_equal(s$status, "ok")
+  expect_equal(s$n_valid, 3L)
+  expect_equal(s$n_attempts, 4L)
+  expect_equal(s$median_throughput, 110)
+  expect_equal(s$tput_lo, 100); expect_equal(s$tput_hi, 120)
+  expect_equal(s$unit, "GFLOPS")
+  expect_true(s$verified)
+  expect_length(s$attempts, 3L)         # every attempt retained verbatim
+})
+
+test_that("skeleton_summary shapes for not-built / skipped / non-measurable", {
+  cfg <- list(id = "k", exe = "e", src = "e.cu", args = character(0),
+              spec_source = "known", measurable = FALSE, verified = FALSE,
+              unit = NA_character_, notes = "table")
+  nb <- skeleton_summary(cfg, "not-built", 0L, 0L, "exe not built")
+  expect_equal(nb$status, "not-built")
+  expect_false(nb$measurable)
+  nm <- skeleton_summary(cfg, "non-measurable", 0L, 1L, "ran; no number",
+                         attempts = list(list(attempt = 1L)))
+  expect_equal(nm$status, "non-measurable")
+  expect_length(nm$attempts, 1L)
+})
+
+# ---- render: the advisor invariant ----------------------------------
+test_that("render keeps measurable / non-measurable / default buckets separate", {
+  meta <- list(ts_utc = "2026-06-04T00:00:00Z", git_head = "abc123",
+               git_dirty = FALSE, host = "h", gpu_name = "g",
+               driver_version = "1", sm_arch = "sm_86", nvcc = "CUDA 13",
+               gpu_mode = "dgpu", clock_lock = "native")
+  mk <- function(id, src, status, measurable, verified) list(
+    id = id, exe = id, src = "x", args = character(0), spec_source = src,
+    measurable = measurable, verified = verified, status = status,
+    n_valid = 0L, n_attempts = 1L, median_throughput = NA_real_,
+    median_ms = NA_real_, tput_lo = NA_real_, tput_hi = NA_real_,
+    unit = NA_character_, reject_buckets = list(), top_reject = "parse-fail:1",
+    notes = "")
+  ss <- list(
+    mk("perf_ok",   "known",   "ok",             TRUE,  TRUE),
+    mk("nm_table",  "known",   "non-measurable", FALSE, FALSE),
+    mk("def_fail",  "default", "failed",         TRUE,  FALSE))
+  md <- render_summary_md(meta, ss)
+
+  # Three labelled sections exist.
+  expect_true(grepl("## Measurable corpus", md, fixed = TRUE))
+  expect_true(grepl("## Non-measurable / skipped", md, fixed = TRUE))
+  expect_true(grepl("## Discovered without a spec", md, fixed = TRUE))
+
+  # The default-args FAILED config must NOT sit above the non-measurable
+  # header (i.e. it is in the default bucket, not the measurable one) --
+  # a default/parse-fail must never read as a real kernel failure.
+  pos_meas    <- regexpr("## Measurable corpus", md, fixed = TRUE)
+  pos_nonmeas <- regexpr("## Non-measurable / skipped", md, fixed = TRUE)
+  pos_default <- regexpr("## Discovered without a spec", md, fixed = TRUE)
+  pos_deffail <- regexpr("def_fail", md, fixed = TRUE)
+  pos_nmtable <- regexpr("nm_table", md, fixed = TRUE)
+  pos_perfok  <- regexpr("perf_ok", md, fixed = TRUE)
+  expect_true(pos_perfok  > pos_meas    && pos_perfok  < pos_nonmeas) # measurable bucket
+  expect_true(pos_nmtable > pos_nonmeas && pos_nmtable < pos_default) # non-measurable bucket
+  expect_true(pos_deffail > pos_default)                              # default bucket
+  # verified marker rendered.
+  expect_true(grepl("verified", md, fixed = TRUE))
+  expect_true(grepl("infer", md, fixed = TRUE))
+})
+
+cat("bench_all.R unit tests defined.\n")


### PR DESCRIPTION
## Summary

Adds `make bench-all` — a one-click **full-corpus** benchmark runner backed by `scripts/bench/bench_all.R`. Builds the whole kernel corpus, runs **every** bench, retries each measurable config to `--min-valid` clean samples, classifies every attempt from its pre/post `capture_gpu_state()` snapshot, **never aborts**, and writes a timestamped report (`results/bench_all/<ts>/{results.json,summary.md,samples.jsonl}`).

The fast regression gate (`make bench` / `bench_regress.R`, 5 baselined kernels) is **unchanged**. `bench-all` is the on-demand "collect everything" pass.

Implements the epic **#124** (epic stays open — this is the runner; follow-ups remain). Design basis: `docs/benchmark_methodology.md` "run everything" section.

## What's in the diff

- **`scripts/bench/bench_all.R`** (635 LOC) — discovers the corpus exactly as `$(BENCH_EXES)` (shell-free), runs every bench, retries via the cuasmR pipeline (`run_bench → parse_throughput → validate_sample → collect_valid_samples → report_median_metrics`), never aborts. **Reuses the cuasmR 0.2.0 API; reimplements nothing.**
- **`scripts/bench/bench_all.yml`** — all **48** corpus exes specced (50 configs). 32 measurable, 16 `non-measurable` (sweep tables / ms-only pipelines / correctness harnesses → run once, parse-miss expected, never `failed`), 2 `run:false`. A `verified` vs `infer` flag separates baseline/sweep-confirmed specs (7) from source-inferred.
- **`Makefile`** `bench-all` target (depends on `all`).
- **`.gitignore`** re-includes `scripts/bench/*.yml` + `tests/bench_all/` (the `bench_*` rule swallowed them, cf. #134); generated `results/bench_all/` stays ignored.
- **Docs**: `docs/benchmark_methodology.md`, `CHANGELOG.md`, `scripts/README.md`.
- **`tests/bench_all/test_bench_all.R`** — 55 GPU-free assertions, all pass (Linux R 4.6.0): corpus discovery, spec merge, status/aggregation, render-bucket separation (the advisor invariant), full-spec corpus coverage.

## Make-or-break (advisor)

A non-perf / inferred / default parse-miss must **never** read as a real kernel failure. Handled by the `measurable` / `non-measurable` / `skipped` taxonomy + `verified`/`infer` flag + three segregated report buckets.

## GPU validation

`make bench-all --min-valid 3 --max-attempts 6` (native): ok=18, degraded=2, failed=19, non-measurable=9, skipped=2. `infer` parse hints confirmed for the bulk (sgemm, conv2d_nhwc, igemm_sparse_persistent, flash_attn_multihead, cross_attn_pipelined, all GB/s reductions + activations, cuBLAS/cuDNN refs). One hint bug found + fixed in-branch (`ref_cusparselt_igemm_sparse` value_label `dense-equiv TOPS`→`TOPS`).

## Surfaced (not caused by) this PR

The full-corpus run exposed a pre-existing bench↔cubin name mismatch in the BenchDriver-refactored flash/resblock/attention benches (~16 benches `cuModuleLoad … file not found`) — filed as **#148**. Out of scope here; the runner recorded them honestly, which is the point of a "run everything" pass.

## Acceptance criteria (#124)

- [x] `make bench-all` builds the corpus then runs `bench_all.R`
- [x] Every bench exe attempted; nothing silently skipped
- [x] Each config retried to `MIN_VALID` or `MAX_ATTEMPTS`
- [x] Throttled/failed runs recorded with status, not dropped
- [x] Output JSON contains every attempt + per-config summary + run metadata
- [x] Runner never aborts on a single bench failure
- [x] `make bench` / `bench_regress.R` regression gate unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
