### PR TITLE
fix(bench): #148 — realign bench cubin names to built artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,25 @@ historical reference.
   map. `Makefile` per-family `bench_%` rules collapsed to a single
   pattern.
 
+### Fixed
+- **bench↔cubin name mismatch across BenchDriver-refactored benches
+  (#148).** ~16 flash-attention, resblock, and attention-layer benches
+  called `load_kernel("<basename>.sm_86.cubin", …)` with abbreviated
+  cubin basenames the build never emits (`flash_*` instead of
+  `flash_attn_*`, `resblock` instead of `resblock_fused`), so they
+  crashed at runtime with `cuModuleLoad … file not found`. These
+  benches are outside `make test`'s smoke loop, so the breakage was
+  silent until the `make bench-all` full-corpus runner (#124) surfaced
+  it. Corrected every load basename to the actual built cubin (the
+  least-churn option, matching #127). Three further sub-fixes:
+  `bench_br16_regpv_pad`'s two compile-time pad variants (`kv8_w0`,
+  `kv0_w4`) now have explicit `-D` Makefile rules and join
+  `KERNEL_CUBINS` (the default `make` cubin is the `kv8_w4` layout);
+  `attention_layer/bench` also had a redundant `kernels/` segment in
+  its cross-directory load paths (`../../kernels/…` → `../../…`), fixed
+  so it resolves from the bench's own working directory. All 16
+  affected benches now load and run; verified by direct per-bench runs.
+
 ### Removed
 - `.github/issues/*.md` and `scripts/create_issues.sh`. All 16
   seed files corresponded to GitHub issues that have been

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,16 @@ BENCH_CU    := $(shell find . \( -path ./tools -o -path ./experiments -o -path .
 KERNEL_CUBINS := $(KERNEL_CU:.cu=.$(SM_ARCH).cubin)
 BENCH_EXES    := $(BENCH_CU:.cu=)
 
+# Compile-time pad-sweep variants of flash_attn_br16_regpv_pad — bench_br16_regpv_pad
+# loads all three layouts. kv8_w4 is the DEFAULT build (KV_PAD_HALFS=8,
+# SCORE_PAD_FLOATS=4 are the kernel defaults), already covered by the %.cubin
+# pattern rule. kv8_w0 and kv0_w4 need explicit -D macros (dedicated rules below),
+# so they are appended to KERNEL_CUBINS here to join `make cubins` / `make all`.
+FLASH_REGPV_PAD_VARIANTS := \
+  kernels/attention/flash_attention/flash_attn_br16_regpv_pad_kv8_w0.$(SM_ARCH).cubin \
+  kernels/attention/flash_attention/flash_attn_br16_regpv_pad_kv0_w4.$(SM_ARCH).cubin
+KERNEL_CUBINS += $(FLASH_REGPV_PAD_VARIANTS)
+
 # Family-specific bench executables.
 GEMM_BENCH         := $(shell find kernels/gemm          -name 'bench*.cu' 2>/dev/null | sed 's/\.cu//')
 REDUCTIONS_BENCH   := $(shell find kernels/reductions    -name 'bench*.cu' 2>/dev/null | sed 's/\.cu//')
@@ -81,6 +91,19 @@ benches: $(BENCH_EXES)
 	@echo "[CUBIN] $<"
 	@mkdir -p $(dir $@)
 	$(NVCC) $(CUBIN_FLAGS) -o $@ $<
+
+# Pad-sweep variants of flash_attn_br16_regpv_pad: same source, different
+# compile-time smem layout (see bench_br16_regpv_pad.cu). These explicit rules
+# override the %.cubin pattern (no matching .cu exists for the variant names).
+kernels/attention/flash_attention/flash_attn_br16_regpv_pad_kv8_w0.$(SM_ARCH).cubin: kernels/attention/flash_attention/flash_attn_br16_regpv_pad.cu
+	@echo "[CUBIN] $< (KV_PAD_HALFS=8 SCORE_PAD_FLOATS=0)"
+	@mkdir -p $(dir $@)
+	$(NVCC) $(CUBIN_FLAGS) -DKV_PAD_HALFS=8 -DSCORE_PAD_FLOATS=0 -o $@ $<
+
+kernels/attention/flash_attention/flash_attn_br16_regpv_pad_kv0_w4.$(SM_ARCH).cubin: kernels/attention/flash_attention/flash_attn_br16_regpv_pad.cu
+	@echo "[CUBIN] $< (KV_PAD_HALFS=0 SCORE_PAD_FLOATS=4)"
+	@mkdir -p $(dir $@)
+	$(NVCC) $(CUBIN_FLAGS) -DKV_PAD_HALFS=0 -DSCORE_PAD_FLOATS=4 -o $@ $<
 
 # Generic bench rule for kernels/<family>/<kernel>/bench.cu.
 kernels/%/bench: kernels/%/bench.cu

--- a/kernels/attention/flash_attention/bench_bc128.cu
+++ b/kernels/attention/flash_attention/bench_bc128.cu
@@ -66,8 +66,8 @@ int main(void) {
     driver.init_context();
 
     CUmodule mod_base, mod_bc128;
-    CHECK_CU(cuModuleLoad(&mod_base,  "flash_br16.sm_86.cubin"));
-    CHECK_CU(cuModuleLoad(&mod_bc128, "flash_br16_bc128.sm_86.cubin"));
+    CHECK_CU(cuModuleLoad(&mod_base,  "flash_attn_br16.sm_86.cubin"));
+    CHECK_CU(cuModuleLoad(&mod_bc128, "flash_attn_br16_bc128.sm_86.cubin"));
 
     CUfunction fn_base, fn_bc128;
     CHECK_CU(cuModuleGetFunction(&fn_base,  mod_base,  "flash_attn_br16"));

--- a/kernels/attention/flash_attention/bench_br16.cu
+++ b/kernels/attention/flash_attention/bench_br16.cu
@@ -101,8 +101,8 @@ int main(int argc, char **argv) {
     driver.copy_h2d(dKh, hKh, ne * sizeof(__half));
     driver.copy_h2d(dVh, hVh, ne * sizeof(__half));
 
-    CUfunction fn_4w = driver.load_kernel("flash_wmma.sm_86.cubin", "flash_attn_4warp");
-    CUfunction fn_br = driver.load_kernel("flash_br16.sm_86.cubin", "flash_attn_br16");
+    CUfunction fn_4w = driver.load_kernel("flash_attn_wmma.sm_86.cubin", "flash_attn_4warp");
+    CUfunction fn_br = driver.load_kernel("flash_attn_br16.sm_86.cubin", "flash_attn_br16");
 
     size_t smem_br = 2 * Bc * d * sizeof(__half)
                    + Br_block * Bc * sizeof(float)

--- a/kernels/attention/flash_attention/bench_br16_regpv_pad.cu
+++ b/kernels/attention/flash_attention/bench_br16_regpv_pad.cu
@@ -2,13 +2,17 @@
  * bench_br16_regpv_pad.cu — Padded smem variants vs unpadded regpv baseline
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16_regpv.sm_86.cubin flash_attn_br16_regpv.cu
- *   nvcc --cubin -arch=sm_86 -O2 -DKV_PAD_HALFS=8 -DSCORE_PAD_FLOATS=4 \
- *        -o flash_br16_regpv_pad_kv8_w4.sm_86.cubin flash_attn_br16_regpv_pad.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16_regpv.sm_86.cubin flash_attn_br16_regpv.cu
+ *   # kv8_w4 is the DEFAULT build (KV_PAD_HALFS=8, SCORE_PAD_FLOATS=4 are the
+ *   # kernel defaults), emitted by the Makefile %.cubin pattern rule as
+ *   # flash_attn_br16_regpv_pad.sm_86.cubin — no -D needed.
+ *   nvcc --cubin -arch=sm_86 -O2 \
+ *        -o flash_attn_br16_regpv_pad.sm_86.cubin flash_attn_br16_regpv_pad.cu
+ *   # kv8_w0 / kv0_w4 need explicit -D builds (see Makefile param rules):
  *   nvcc --cubin -arch=sm_86 -O2 -DKV_PAD_HALFS=8 -DSCORE_PAD_FLOATS=0 \
- *        -o flash_br16_regpv_pad_kv8_w0.sm_86.cubin flash_attn_br16_regpv_pad.cu
+ *        -o flash_attn_br16_regpv_pad_kv8_w0.sm_86.cubin flash_attn_br16_regpv_pad.cu
  *   nvcc --cubin -arch=sm_86 -O2 -DKV_PAD_HALFS=0 -DSCORE_PAD_FLOATS=4 \
- *        -o flash_br16_regpv_pad_kv0_w4.sm_86.cubin flash_attn_br16_regpv_pad.cu
+ *        -o flash_attn_br16_regpv_pad_kv0_w4.sm_86.cubin flash_attn_br16_regpv_pad.cu
  *   nvcc -arch=sm_86 -O2 -o bench_br16_regpv_pad bench_br16_regpv_pad.cu \
  *        -lcuda -I../../kernels/_common
  */
@@ -75,14 +79,14 @@ int main(int argc, char **argv) {
     }
 
     Variant variants[] = {
-        { "flash_br16_regpv.sm_86.cubin",            "flash_attn_br16_regpv",      "regpv (baseline)            ", 0, 0, false },
-        { "flash_br16_regpv_lean.sm_86.cubin",       "flash_attn_br16_regpv_lean",        "regpv_lean (4 reg state)    ", 0, 0, false },
-        { "flash_br16_regpv_lean_qcache.sm_86.cubin", "flash_attn_br16_regpv_lean_qcache", "regpv_lean + Q reg cache    ", 0, 0, false },
-        { "flash_br16_v2.sm_86.cubin",                "flash_attn_br16_v2",                "flash_attn_br16_v2 (winner) ", 0, 0, true  },
-        { "flash_br16_regpv_full.sm_86.cubin",       "flash_attn_br16_regpv_full",        "+ pad K/V/W (27 KB, no conf)", 8, 0, false },
-        { "flash_br16_regpv_pad_kv8_w4.sm_86.cubin", "flash_attn_br16_regpv_pad",  "regpv + KV+8 + W+4 (both)   ", 8, 4, false },
-        { "flash_br16_regpv_pad_kv8_w0.sm_86.cubin", "flash_attn_br16_regpv_pad",  "regpv + KV+8 only           ", 8, 0, false },
-        { "flash_br16_regpv_pad_kv0_w4.sm_86.cubin", "flash_attn_br16_regpv_pad",  "regpv + W+4 only            ", 0, 4, false },
+        { "flash_attn_br16_regpv.sm_86.cubin",            "flash_attn_br16_regpv",      "regpv (baseline)            ", 0, 0, false },
+        { "flash_attn_br16_regpv_lean.sm_86.cubin",       "flash_attn_br16_regpv_lean",        "regpv_lean (4 reg state)    ", 0, 0, false },
+        { "flash_attn_br16_regpv_lean_qcache.sm_86.cubin", "flash_attn_br16_regpv_lean_qcache", "regpv_lean + Q reg cache    ", 0, 0, false },
+        { "flash_attn_br16_v2.sm_86.cubin",                "flash_attn_br16_v2",                "flash_attn_br16_v2 (winner) ", 0, 0, true  },
+        { "flash_attn_br16_regpv_full.sm_86.cubin",       "flash_attn_br16_regpv_full",        "+ pad K/V/W (27 KB, no conf)", 8, 0, false },
+        { "flash_attn_br16_regpv_pad.sm_86.cubin",         "flash_attn_br16_regpv_pad",  "regpv + KV+8 + W+4 (both)   ", 8, 4, false },
+        { "flash_attn_br16_regpv_pad_kv8_w0.sm_86.cubin", "flash_attn_br16_regpv_pad",  "regpv + KV+8 only           ", 8, 0, false },
+        { "flash_attn_br16_regpv_pad_kv0_w4.sm_86.cubin", "flash_attn_br16_regpv_pad",  "regpv + W+4 only            ", 0, 4, false },
     };
     int n_var = sizeof(variants) / sizeof(variants[0]);
 

--- a/kernels/attention/flash_attention/bench_fused.cu
+++ b/kernels/attention/flash_attention/bench_fused.cu
@@ -4,8 +4,8 @@
  * Eliminates transpose kernels by accepting [B,S,H,D] layout directly.
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_fused.sm_86.cubin flash_attn_fused.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16.sm_86.cubin flash_attn_br16.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_fused.sm_86.cubin flash_attn_fused.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16.sm_86.cubin flash_attn_br16.cu
  *   nvcc -arch=sm_86 -O2 -o bench_fused bench_fused.cu -lcuda -I../../kernels/_common
  */
 
@@ -98,8 +98,8 @@ int main(int argc, char **argv) {
     driver.copy_h2d(dKh, hKh, nbh);
     driver.copy_h2d(dVh, hVh, nbh);
 
-    CUfunction fn_br16  = driver.load_kernel("flash_br16.sm_86.cubin",  "flash_attn_br16");
-    CUfunction fn_fused = driver.load_kernel("flash_fused.sm_86.cubin", "flash_attn_fused");
+    CUfunction fn_br16  = driver.load_kernel("flash_attn_br16.sm_86.cubin",  "flash_attn_br16");
+    CUfunction fn_fused = driver.load_kernel("flash_attn_fused.sm_86.cubin", "flash_attn_fused");
 
     size_t smem = 2 * Br_block * d * sizeof(__half) + Br_block * Br_block * sizeof(float) + Br_block * d * sizeof(float);
     CHECK_CU(cuFuncSetAttribute(fn_br16,  CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (int)smem));

--- a/kernels/attention/flash_attention/bench_persistent.cu
+++ b/kernels/attention/flash_attention/bench_persistent.cu
@@ -4,8 +4,8 @@
  * Tests SM utilization improvement at small batch sizes.
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16.sm_86.cubin flash_attn_br16.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_persistent.sm_86.cubin flash_attn_persistent.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16.sm_86.cubin flash_attn_br16.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_persistent.sm_86.cubin flash_attn_persistent.cu
  *   nvcc -arch=sm_86 -O2 -o bench_persistent bench_persistent.cu -lcuda -I../../kernels/_common
  */
 
@@ -63,8 +63,8 @@ int main(int argc, char **argv) {
     CHECK_CU(cuDeviceGetAttribute(&num_sms, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, driver.device));
     printf("SMs: %d\n\n", num_sms);
 
-    CUfunction fn_br16    = driver.load_kernel("flash_br16.sm_86.cubin",      "flash_attn_br16");
-    CUfunction fn_persist = driver.load_kernel("flash_persistent.sm_86.cubin","flash_attn_persistent");
+    CUfunction fn_br16    = driver.load_kernel("flash_attn_br16.sm_86.cubin",      "flash_attn_br16");
+    CUfunction fn_persist = driver.load_kernel("flash_attn_persistent.sm_86.cubin","flash_attn_persistent");
 
     size_t smem = 2 * Bc * d * sizeof(__half) + Br_block * Bc * sizeof(float) + Br_block * d * sizeof(float);
     CHECK_CU(cuFuncSetAttribute(fn_br16,    CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (int)smem));

--- a/kernels/attention/flash_attention/bench_pipeline.cu
+++ b/kernels/attention/flash_attention/bench_pipeline.cu
@@ -64,8 +64,8 @@ int main(void) {
     driver.init_context();
 
     CUmodule mod_base, mod_pipe;
-    CHECK_CU(cuModuleLoad(&mod_base, "flash_br16.sm_86.cubin"));
-    CHECK_CU(cuModuleLoad(&mod_pipe, "flash_br16_pipeline.sm_86.cubin"));
+    CHECK_CU(cuModuleLoad(&mod_base, "flash_attn_br16.sm_86.cubin"));
+    CHECK_CU(cuModuleLoad(&mod_pipe, "flash_attn_br16_pipeline.sm_86.cubin"));
     CUfunction fn_base, fn_pipe;
     CHECK_CU(cuModuleGetFunction(&fn_base, mod_base, "flash_attn_br16"));
     CHECK_CU(cuModuleGetFunction(&fn_pipe, mod_pipe, "flash_attn_br16_pipeline"));

--- a/kernels/attention/flash_attention/bench_split_q.cu
+++ b/kernels/attention/flash_attention/bench_split_q.cu
@@ -4,8 +4,8 @@
  * Tests flash_attn_split_q + reduce vs flash_attn_br16 baseline.
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16.sm_86.cubin flash_attn_br16.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_split_q.sm_86.cubin flash_attn_split_q.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16.sm_86.cubin flash_attn_br16.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_split_q.sm_86.cubin flash_attn_split_q.cu
  *   nvcc -arch=sm_86 -O2 -o bench_split_q bench_split_q.cu -lcuda -I../../kernels/_common
  */
 
@@ -65,13 +65,13 @@ int main(int argc, char **argv) {
     BenchDriver driver;
     driver.init_context();
 
-    CUfunction fn_br16   = driver.load_kernel("flash_br16.sm_86.cubin", "flash_attn_br16");
+    CUfunction fn_br16   = driver.load_kernel("flash_attn_br16.sm_86.cubin", "flash_attn_br16");
 
     // Manual module load for split-q (need 2 kernels from 1 module)
     CUmodule mod_split;
     CUfunction fn_split, fn_reduce;
-    if (cuModuleLoad(&mod_split, "flash_split_q.sm_86.cubin") != CUDA_SUCCESS) {
-        fprintf(stderr, "Cannot load flash_split_q.sm_86.cubin\n"); return 1;
+    if (cuModuleLoad(&mod_split, "flash_attn_split_q.sm_86.cubin") != CUDA_SUCCESS) {
+        fprintf(stderr, "Cannot load flash_attn_split_q.sm_86.cubin\n"); return 1;
     }
     CHECK_CU(cuModuleGetFunction(&fn_split, mod_split, "flash_attn_split_q"));
     CHECK_CU(cuModuleGetFunction(&fn_reduce, mod_split, "flash_attn_split_q_reduce"));

--- a/kernels/attention/flash_attention/bench_v2_baseline_pad.cu
+++ b/kernels/attention/flash_attention/bench_v2_baseline_pad.cu
@@ -5,8 +5,8 @@
  * 2.36× on v2_pipeline) transfers to the non-pipelined v2 baseline.
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16_v2.sm_86.cubin     flash_attn_br16_v2.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16_v2_pad.sm_86.cubin flash_attn_br16_v2_pad.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16_v2.sm_86.cubin     flash_attn_br16_v2.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16_v2_pad.sm_86.cubin flash_attn_br16_v2_pad.cu
  *   nvcc -arch=sm_86 -O2 -o bench_v2_baseline_pad bench_v2_baseline_pad.cu \
  *        -lcuda -I../../kernels/_common
  */
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
 
     // unpadded baseline: K + V + W = 3 × Bc × d
     size_t smem_unpad = 3 * (size_t)Bc * d * sizeof(__half);
-    double gf_unpad = run_variant("flash_br16_v2.sm_86.cubin",
+    double gf_unpad = run_variant("flash_attn_br16_v2.sm_86.cubin",
                                    "flash_attn_br16_v2",
                                    "v2 baseline (unpadded, 24 KB)", smem_unpad);
 
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
     const int D_STRIDE = 72;
     size_t smem_pad = 2 * (size_t)Bc * D_STRIDE * sizeof(__half)   // K_tile + V_tile
                     + (size_t)Br_block * D_STRIDE * sizeof(__half); // weight_smem (uses W_STRIDE=72 too)
-    double gf_pad   = run_variant("flash_br16_v2_pad.sm_86.cubin",
+    double gf_pad   = run_variant("flash_attn_br16_v2_pad.sm_86.cubin",
                                    "flash_attn_br16_v2_pad",
                                    "v2 baseline_pad (+8 K/V/W, 27 KB)", smem_pad);
 

--- a/kernels/attention/flash_attention/bench_v2_persistent_pad.cu
+++ b/kernels/attention/flash_attention/bench_v2_persistent_pad.cu
@@ -2,8 +2,8 @@
  * bench_v2_persistent_pad.cu — A/B test of v2_persistent vs v2_persistent_pad.
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_v2_persistent.sm_86.cubin     flash_attn_v2_persistent.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_v2_persistent_pad.sm_86.cubin flash_attn_v2_persistent_pad.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_v2_persistent.sm_86.cubin     flash_attn_v2_persistent.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_v2_persistent_pad.sm_86.cubin flash_attn_v2_persistent_pad.cu
  *   nvcc -arch=sm_86 -O2 -o bench_v2_persistent_pad bench_v2_persistent_pad.cu \
  *        -lcuda -I../../kernels/_common
  */
@@ -167,14 +167,14 @@ int main(int argc, char **argv) {
 
     size_t smem_unpad = 2 * (size_t)Bc * d * sizeof(__half)
                       + (size_t)Br_block * Bc * sizeof(__half);
-    double gf_unpad = run_variant("flash_v2_persistent.sm_86.cubin",
+    double gf_unpad = run_variant("flash_attn_v2_persistent.sm_86.cubin",
                                    "flash_attn_v2_persistent",
                                    "v2 persistent (unpadded, 24 KB)", smem_unpad);
 
     const int D_STRIDE = 72;
     size_t smem_pad = 2 * (size_t)Bc * D_STRIDE * sizeof(__half)
                     + (size_t)Br_block * D_STRIDE * sizeof(__half);
-    double gf_pad   = run_variant("flash_v2_persistent_pad.sm_86.cubin",
+    double gf_pad   = run_variant("flash_attn_v2_persistent_pad.sm_86.cubin",
                                    "flash_attn_v2_persistent_pad",
                                    "v2 persistent_pad (+8, 27 KB)", smem_pad);
 

--- a/kernels/attention/flash_attention/bench_v2_pipeline_pad.cu
+++ b/kernels/attention/flash_attention/bench_v2_pipeline_pad.cu
@@ -6,8 +6,8 @@
  * from 87.5% to ~0%, stall_short_sb + stall_mio drop substantially.
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16_v2_pipeline.sm_86.cubin     flash_attn_br16_v2_pipeline.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16_v2_pipeline_pad.sm_86.cubin flash_attn_br16_v2_pipeline_pad.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16_v2_pipeline.sm_86.cubin     flash_attn_br16_v2_pipeline.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16_v2_pipeline_pad.sm_86.cubin flash_attn_br16_v2_pipeline_pad.cu
  *   nvcc -arch=sm_86 -O2 -o bench_v2_pipeline_pad bench_v2_pipeline_pad.cu \
  *        -lcuda -I../../kernels/_common
  */
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
     // unpadded: K_tile + V_tile = 2 × (Bc × d) bytes × 2 buffers + weight
     size_t smem_unpad = 2 * 2 * (size_t)Bc * d * sizeof(__half)
                       + (size_t)Br_block * Bc * sizeof(__half);
-    double gf_unpad = run_variant("flash_br16_v2_pipeline.sm_86.cubin",
+    double gf_unpad = run_variant("flash_attn_br16_v2_pipeline.sm_86.cubin",
                                   "flash_attn_br16_v2_pipeline",
                                   "v2 pipeline (unpadded, 40 KB)", smem_unpad);
 
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
     const int D_STRIDE = 72;
     size_t smem_pad = 2 * 2 * (size_t)Bc * D_STRIDE * sizeof(__half)
                     + (size_t)Br_block * Bc * sizeof(__half);
-    double gf_pad   = run_variant("flash_br16_v2_pipeline_pad.sm_86.cubin",
+    double gf_pad   = run_variant("flash_attn_br16_v2_pipeline_pad.sm_86.cubin",
                                   "flash_attn_br16_v2_pipeline_pad",
                                   "v2 pipeline_pad (+8 K/V, 44 KB)", smem_pad);
 
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
     const int W_STRIDE = 72;
     size_t smem_pad2 = 2 * 2 * (size_t)Bc * D_STRIDE * sizeof(__half)
                      + (size_t)Br_block * W_STRIDE * sizeof(__half);
-    double gf_pad2  = run_variant("flash_br16_v2_pipeline_pad2.sm_86.cubin",
+    double gf_pad2  = run_variant("flash_attn_br16_v2_pipeline_pad2.sm_86.cubin",
                                   "flash_attn_br16_v2_pipeline_pad2",
                                   "v2 pipeline_pad2 (+8 K/V/W, 45 KB)", smem_pad2);
 

--- a/kernels/attention/flash_attention/bench_v2_variants.cu
+++ b/kernels/attention/flash_attention/bench_v2_variants.cu
@@ -2,9 +2,9 @@
  * bench_v2_variants.cu — Compare v2 baseline, v2_pipeline, v2_persistent
  *
  * Build:
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16_v2.sm_86.cubin flash_attn_br16_v2.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_br16_v2_pipeline.sm_86.cubin flash_attn_br16_v2_pipeline.cu
- *   nvcc --cubin -arch=sm_86 -O2 -o flash_v2_persistent.sm_86.cubin flash_attn_v2_persistent.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16_v2.sm_86.cubin flash_attn_br16_v2.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_br16_v2_pipeline.sm_86.cubin flash_attn_br16_v2_pipeline.cu
+ *   nvcc --cubin -arch=sm_86 -O2 -o flash_attn_v2_persistent.sm_86.cubin flash_attn_v2_persistent.cu
  *   nvcc -arch=sm_86 -O2 -o bench_v2_variants bench_v2_variants.cu \
  *        -lcuda -I../../kernels/_common
  */
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
 
     // ---- v2 baseline ----
     {
-        CUfunction fn = driver.load_kernel("flash_br16_v2.sm_86.cubin", "flash_attn_br16_v2");
+        CUfunction fn = driver.load_kernel("flash_attn_br16_v2.sm_86.cubin", "flash_attn_br16_v2");
         size_t smem = 2 * (size_t)Bc * d * sizeof(__half) + (size_t)Br_block * Bc * sizeof(__half);
         CHECK_CU(cuFuncSetAttribute(fn, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (int)smem));
         int regs = 0, blocks = 0;
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
 
     // ---- v2 pipeline (cp.async double-buffered K/V) ----
     {
-        CUfunction fn = driver.load_kernel("flash_br16_v2_pipeline.sm_86.cubin", "flash_attn_br16_v2_pipeline");
+        CUfunction fn = driver.load_kernel("flash_attn_br16_v2_pipeline.sm_86.cubin", "flash_attn_br16_v2_pipeline");
         size_t smem = 2 * 2 * (size_t)Bc * d * sizeof(__half)        // 2 buffers × K + V each = 32 KB
                     + (size_t)Br_block * Bc * sizeof(__half);          // weight 8 KB
         CHECK_CU(cuFuncSetAttribute(fn, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (int)smem));
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
 
     // ---- v2 persistent ----
     {
-        CUfunction fn = driver.load_kernel("flash_v2_persistent.sm_86.cubin", "flash_attn_v2_persistent");
+        CUfunction fn = driver.load_kernel("flash_attn_v2_persistent.sm_86.cubin", "flash_attn_v2_persistent");
         size_t smem = 2 * (size_t)Bc * d * sizeof(__half) + (size_t)Br_block * Bc * sizeof(__half);
         CHECK_CU(cuFuncSetAttribute(fn, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (int)smem));
         int regs = 0, blocks = 0;
@@ -242,7 +242,7 @@ int main(int argc, char **argv) {
     // ---- v2 Bc=128 (issue #29 follow-up: bigger inner-K tile) ----
     {
         const int Bc128 = 128;
-        CUfunction fn = driver.load_kernel("flash_br16_v2_bc128.sm_86.cubin", "flash_attn_br16_v2_bc128");
+        CUfunction fn = driver.load_kernel("flash_attn_br16_v2_bc128.sm_86.cubin", "flash_attn_br16_v2_bc128");
         size_t smem = 2 * (size_t)Bc128 * d * sizeof(__half) + (size_t)Br_block * Bc128 * sizeof(__half);
         CHECK_CU(cuFuncSetAttribute(fn, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, (int)smem));
         int regs = 0, blocks = 0;

--- a/kernels/attention/flash_attention/bench_wmma.cu
+++ b/kernels/attention/flash_attention/bench_wmma.cu
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     driver.copy_h2d(dV, hV, sb);
 
     CUfunction fn_v1 = driver.load_kernel("flash_attn.sm_86.cubin", "flash_attn_multihead");
-    CUfunction fn_v2 = driver.load_kernel("flash_wmma.sm_86.cubin", "flash_attn_4warp");
+    CUfunction fn_v2 = driver.load_kernel("flash_attn_wmma.sm_86.cubin", "flash_attn_4warp");
 
     int n1 = 1;
     void *args1[] = { &dQ.ptr, &dK.ptr, &dV.ptr, &dO.ptr, &seq_len, &n1, &scale };

--- a/kernels/composition/attention_layer/bench.cu
+++ b/kernels/composition/attention_layer/bench.cu
@@ -97,10 +97,10 @@ int main(int argc, char **argv) {
     // Load modules manually (multiple fns per module needed)
     CUmodule mod_ln, mod_hg, mod_fl, mod_fu, mod_ut;
     auto ld = [&](const char* p) { CUmodule m; if (cuModuleLoad(&m,p)!=CUDA_SUCCESS){fprintf(stderr,"Cannot load %s\n",p);exit(1);} return m; };
-    mod_ln = ld("../../kernels/reductions/layernorm/layernorm.sm_86.cubin");
-    mod_hg = ld("../../kernels/gemm/hgemm/hgemm.sm_86.cubin");
-    mod_fl = ld("../../kernels/attention/flash_attention/flash_br16.sm_86.cubin");
-    mod_fu = ld("../../kernels/attention/flash_attention/flash_fused.sm_86.cubin");
+    mod_ln = ld("../../reductions/layernorm/layernorm.sm_86.cubin");
+    mod_hg = ld("../../gemm/hgemm/hgemm.sm_86.cubin");
+    mod_fl = ld("../../attention/flash_attention/flash_attn_br16.sm_86.cubin");
+    mod_fu = ld("../../attention/flash_attention/flash_attn_fused.sm_86.cubin");
     mod_ut = ld("utils.sm_86.cubin");
 
     CUfunction fn_ln, fn_hg, fn_fl, fn_fu, fn_f2h, fn_tr_bshd, fn_tr_bhsd, fn_res;

--- a/kernels/convolution/resblock/bench.cu
+++ b/kernels/convolution/resblock/bench.cu
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
 
     // Load kernels from two cubins
     CUmodule mod_rb, mod_conv;
-    CHECK_CU(cuModuleLoad(&mod_rb, "resblock.sm_86.cubin"));
+    CHECK_CU(cuModuleLoad(&mod_rb, "resblock_fused.sm_86.cubin"));
     CHECK_CU(cuModuleLoad(&mod_conv, "../conv2d/conv2d.sm_86.cubin"));
     CUfunction fn_gn_silu, fn_residual, fn_conv;
     CHECK_CU(cuModuleGetFunction(&fn_gn_silu, mod_rb, "groupnorm_silu_fused"));

--- a/kernels/convolution/resblock/bench_implicit.cu
+++ b/kernels/convolution/resblock/bench_implicit.cu
@@ -166,7 +166,7 @@ int main(int argc, char **argv) {
     driver.copy_h2d(d_W2f, h_W2f, (size_t)K_dim * C * sizeof(__half));
 
     CUmodule mod_rb, mod_conv_ig;
-    CHECK_CU(cuModuleLoad(&mod_rb, "resblock.sm_86.cubin"));
+    CHECK_CU(cuModuleLoad(&mod_rb, "resblock_fused.sm_86.cubin"));
     CHECK_CU(cuModuleLoad(&mod_conv_ig, "../conv2d/conv2d_implicit_gemm.sm_86.cubin"));
     CUfunction fn_gn_silu, fn_residual, fn_conv_ig;
     CHECK_CU(cuModuleGetFunction(&fn_gn_silu, mod_rb, "groupnorm_silu_fused"));

--- a/kernels/convolution/resblock/bench_implicit_v2.cu
+++ b/kernels/convolution/resblock/bench_implicit_v2.cu
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
     driver.copy_h2d(d_W2f, h_W2f, (size_t)K_dim * C * sizeof(__half));
 
     CUmodule mod_rb, mod_conv_v2;
-    CHECK_CU(cuModuleLoad(&mod_rb, "resblock.sm_86.cubin"));
+    CHECK_CU(cuModuleLoad(&mod_rb, "resblock_fused.sm_86.cubin"));
     CHECK_CU(cuModuleLoad(&mod_conv_v2, "../conv2d/conv2d_implicit_gemm_v2.sm_86.cubin"));
     CUfunction fn_gn_silu, fn_residual, fn_conv_v2;
     CHECK_CU(cuModuleGetFunction(&fn_gn_silu, mod_rb, "groupnorm_silu_fused"));


### PR DESCRIPTION
## Summary

Fixes the bench↔cubin name mismatch (#148): ~16 BenchDriver-refactored flash-attention, resblock, and attention-layer benches called `load_kernel("<basename>.sm_86.cubin", …)` with **abbreviated cubin basenames the build never emits** (`flash_*` instead of `flash_attn_*`, `resblock` instead of `resblock_fused`), crashing at runtime with `cuModuleLoad … file not found`. These benches sit outside `make test`'s smoke loop, so the breakage was silent until the `make bench-all` full-corpus runner (#124, PR #149) surfaced it — exactly what a "run everything" pass is for.

Fix follows #148's preferred option 1 (correct the basenames, least churn, matching #127).

## Changes

- **Basename realignment (16 benches):** every `load_kernel`/`cuModuleLoad` string corrected to the actual built cubin. Stale header build-command comments updated to match.
- **`bench_br16_regpv_pad` pad variants (root-cause, not skip):** the `kv8_w4` row points at the default-built cubin (`KV_PAD_HALFS=8`, `SCORE_PAD_FLOATS=4` are the kernel defaults, so the `%.cubin` pattern rule emits exactly that layout). The `kv8_w0` and `kv0_w4` compile-time variants get **explicit `-D` Makefile rules** and join `KERNEL_CUBINS`, so `make cubins` / `make all` emits all three layouts. Verified the wiring by deleting both and rebuilding via `make cubins` (not the explicit targets).
- **`attention_layer/bench` path fix (distinct sub-bug, same symptom):** its cross-directory load paths carried a redundant `kernels/` segment (`../../kernels/…` → `../../…`); from the bench's own working directory `../../` already lands in `kernels/`. A name-only fix would have left it crashing.

## Verification

GPU-recovered, native. **All 16 affected benches now load and run (`rc=0`)**, verified by direct per-bench runs (these are *not* in the smoke loop, so the pre-push gate cannot cover them):

- flash_attention: `bench_bc128, bench_br16, bench_fused, bench_split_q, bench_pipeline, bench_wmma, bench_br16_regpv_pad, bench_persistent, bench_v2_baseline_pad, bench_v2_persistent_pad, bench_v2_pipeline_pad, bench_v2_variants` — all ✅
- resblock: `bench, bench_implicit, bench_implicit_v2` — all ✅
- composition: `attention_layer/bench` — ✅ (full fused-pipeline output)

`bench_br16_regpv_pad` exercises all three pad layouts with **distinct smem (35/34/33 KB)** and correctness ✓ — confirming the param cubins are genuinely different compile-time builds, not one cubin loaded thrice.

Pre-push gate: 7 configs, 0 regressions, 2 skip, PASSED.

## Out of scope

The `bench_all.yml` `infer`-spec status reconciliation (several entries flip `failed`/`non-measurable` → `ok` after this fix) lives on the #124 branch (PR #149) and is handled there, post-merge — `make bench-all` re-validates automatically.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
