### PR TITLE
docs: cross-reference bench tooling (#124 ↔ #135 ↔ #152) + runbook

### DIFF
--- a/docs/CONTINUE_HERE.md
+++ b/docs/CONTINUE_HERE.md
@@ -55,7 +55,10 @@ here is build-graph gaps that "look right" (per-family target vs
 `KERNEL_CUBINS +=` link empirically.
 
 **Next steps (all remaining items need the elevated Windows GPU shell or are
-optional):**
+optional):** → **turnkey runbook:
+[`elevated_session_runbook.md`](elevated_session_runbook.md)** (copy-paste,
+verified pre-flight). North-star convergence goal: **#152** (one tool, all
+kernels × {native and/or locked-clock grid}).
 1. **#135** P2-5 single-Ctrl+C re-test + P2-6 full grid sweep (elevated pwsh).
 2. **#128** OC showcase (deferred; grid-sweep data is its source).
 3. Optional: publication-grade `make bench-all` (default `--min-valid 5`) now

--- a/docs/benchmark_methodology.md
+++ b/docs/benchmark_methodology.md
@@ -269,6 +269,17 @@ baselined kernels); `bench-all` is the on-demand "collect everything"
 pass. For clock/power context around a run, see
 `scripts/probe/probe_gpu_power.R`.
 
+`bench-all` runs **native** (no clock lock), so power-bound configs that
+throttle at native boost land `degraded`/`failed`. For their fair numbers,
+re-measure under a host-side clock lock — see
+[`grid_sweep_methodology.md`](grid_sweep_methodology.md) (#135, the
+multi-kernel × clock grid) and `scripts/probe/run_locked_eval.ps1`. The
+operational runbook for the elevated, clock-locked session is
+[`elevated_session_runbook.md`](elevated_session_runbook.md). The end goal —
+**one** tool running all kernels against native **and/or** a defined
+locked-clock grid, converging this `bench-all` corpus runner with the #135
+grid sweep — is tracked in issue #152.
+
 For the concrete step-by-step procedure to re-record a suspect
 baseline (currently `hgemm` + `igemm_sparse`, recorded under a
 power-supply fault), see

--- a/docs/grid_sweep_methodology.md
+++ b/docs/grid_sweep_methodology.md
@@ -25,6 +25,14 @@ Each tool has a distinct job:
 | `run_locked_eval.ps1`      | Single (kernel, clock) cell + log + JSONL row.|
 | `run_grid_sweep.ps1` (+ R) | Many (kernel × clock) cells; raw data set.  |
 
+The full-corpus, **native** counterpart is `bench_all.R` / `make bench-all`
+(#124; see [`benchmark_methodology.md`](benchmark_methodology.md)): it runs
+*every* kernel, but only at native boost. This grid sweep runs a *subset*
+across *locked* clocks. Converging the two — all kernels × {native and/or a
+locked-clock grid} — is tracked in issue #152. For the operational
+elevated-session runbook, see
+[`elevated_session_runbook.md`](elevated_session_runbook.md).
+
 ## Architecture
 
 Three pieces, three responsibilities. None reach into another's

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,8 @@ prerequisite and 06 as synthesis.
 | [`gpu_reflections.md`](gpu_reflections.md)                                           | Observation catalogue. The first-person voice is a deliberate stylistic experiment; see file preamble. |
 | [`fragment_shfl_reductions.md`](fragment_shfl_reductions.md)                         | Reusable Tensor Core reduction pattern           |
 | [`benchmark_methodology.md`](benchmark_methodology.md)                               | Throttle, the 150 W power cap, clock-lock vs cooldown, reproducibility |
-| [`grid_sweep_methodology.md`](grid_sweep_methodology.md)                             | Multi-kernel × clock grid-sweep tool architecture (#135) |
+| [`grid_sweep_methodology.md`](grid_sweep_methodology.md)                             | Multi-kernel × clock grid-sweep tool architecture (#135); convergence goal #152 |
+| [`elevated_session_runbook.md`](elevated_session_runbook.md)                         | Turnkey runbook for the elevated clock-locked GPU session (#135/#124/#128) |
 | [`rebaseline_protocol.md`](rebaseline_protocol.md)                                   | Re-baselining procedure (executed 2026-05-22; see baselines.json) |
 | [`cymatic_memory_mapping.md`](cymatic_memory_mapping.md)                             | Chladni-pattern memory layout: theory and bench  |
 | [`diffusion_primitives.md`](diffusion_primitives.md)                                 | UNet primitive inventory                         |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,7 @@ scripts/
 │
 ├── bench/                    ── benchmark harnesses (need GPU; measurement via cuasmR, #134)
 │   ├── bench_regress.R       ── runs all benches vs data/baselines.json (the fast gate)
-│   ├── bench_all.R           ── full-corpus "run everything" pass → results/bench_all/ (#124)
+│   ├── bench_all.R           ── full-corpus "run everything" pass, native → results/bench_all/ (#124; converge w/ grid → #152)
 │   ├── bench_all.yml         ── per-bench invocation + parse spec for bench_all.R
 │   ├── bench_meta.R          ── GPU-state capture shim (capture_gpu_state/classify_meta now in cuasmR)
 │   ├── bench_reference.R     ── runs local reference benches vs data/reference_baselines.json
@@ -55,6 +55,7 @@ scripts/
 │   ├── probe_clock_lock.R    ── probe whether host-side -lgc holds
 │   ├── run_grid_sweep.ps1    ── elevated-pwsh grid orchestrator (Ctrl+C-safe -rgc)
 │   └── run_locked_eval.ps1   ── elevated-pwsh single locked-clock eval driver
+│   (elevated-session runbook: docs/elevated_session_runbook.md)
 │
 ├── profile/                  ── NCU profiling + measured roofline
 │   ├── ncu_profile.R         ── ncu wrapper for one kernel → markdown row


### PR DESCRIPTION
Wires the benchmark-tooling docs into one navigable web: benchmark_methodology (#124), grid_sweep_methodology (#135), elevated_session_runbook, index.md, CONTINUE_HERE, scripts/README — each now cross-links the others and threads the convergence goal **#152** (one tool, all kernels × {native and/or locked-clock grid}).

check_links.R: 0 broken. Docs-only; closes no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)