### PR TITLE
fix(bench): the regression gate no longer reports PASSED having measured nothing (#176)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -185,7 +185,11 @@ fi
 case "$regress_rc" in
 0)
     echo ""
-    echo -e "${GREEN}All benchmarks within tolerance. Push allowed.${NC}"
+    # Not "All benchmarks within tolerance" -- that sentence is the one #176 was
+    # filed about. A pass here means every config that was MEASURED was within
+    # tolerance, and on this machine that is routinely 3 of 7.
+    echo -e "${GREEN}Every measured benchmark was within tolerance. Push allowed.${NC}"
+    echo "Skipped configs were not checked — see the Measured count above."
     exit 0
     ;;
 2)

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -156,11 +156,49 @@ if [ ! -f "$REGRESS_SCRIPT" ]; then
     echo -e "${YELLOW}WARNING: $REGRESS_SCRIPT not found — skipping${NC}"
     exit 0
 fi
+# Three outcomes, not two (#176). bench_regress.R exits 0 PASSED, 1 FAILED,
+# 2 INCONCLUSIVE (it measured nothing, so it certifies nothing). Until #176
+# the third case did not exist: an all-skip run exited 0 and this branch
+# printed "All benchmarks within tolerance. Push allowed." having measured
+# zero kernels. It did that on five consecutive real pushes.
+#
+# INCONCLUSIVE warns and allows the push. That is a deliberate choice, not an
+# oversight -- see the hook step table in AGENTS.md. Blocking would reject most
+# pushes on this laptop (three configs sit behind a host-side clock lock this
+# hook never applies, and throttle takes more), and the escape hatch from a
+# blocking gate is `git push --no-verify`, which switches off all five steps
+# including the GPU-free R suites. A warning that is read beats a block that is
+# routinely bypassed.
+#
+# `if ...; then rc=0; else rc=$?; fi` rather than a bare call: this script runs
+# under `set -e`, which would abort on any non-zero status before the case
+# below could tell 1 from 2.
 if Rscript "$REGRESS_SCRIPT"; then
+    regress_rc=0
+else
+    regress_rc=$?
+fi
+
+case "$regress_rc" in
+0)
     echo ""
     echo -e "${GREEN}All benchmarks within tolerance. Push allowed.${NC}"
     exit 0
-else
+    ;;
+2)
+    echo ""
+    echo -e "${YELLOW}BENCHMARKS MEASURED NOTHING${NC} (see the INCONCLUSIVE line above)"
+    echo ""
+    echo "Push allowed, but performance was NOT checked. Every config skipped:"
+    echo "a clock-locked config with no host-side lock, a throttled GPU, or an"
+    echo "unbuilt executable. To actually measure the locked configs:"
+    echo ""
+    echo "  nvidia-smi.exe -lgc 1605,1605      (elevated Windows shell)"
+    echo "  Rscript $REGRESS_SCRIPT --clock-locked 1605"
+    echo "  nvidia-smi.exe -rgc                (release the lock afterwards)"
+    exit 0
+    ;;
+*)
     echo ""
     echo -e "${RED}BENCHMARK REGRESSION DETECTED${NC}"
     echo ""
@@ -174,4 +212,5 @@ else
     echo "To bypass (for WIP commits):"
     echo "  git push --no-verify"
     exit 1
-fi
+    ;;
+esac

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -42,7 +42,10 @@ REGRESS_SCRIPT="scripts/bench/bench_regress.R"
 #   2. renv_check.R    ~2-10 s  GPU-free, deterministic, blocking
 #   3. make test-r     ~2 min   GPU-free, deterministic, blocking      (#163)
 #   4. make test       minutes  CUDA build, best-effort, NON-blocking
-#   5. bench_regress.R minutes  needs the GPU, blocking, power-sensitive
+#   5. bench_regress.R minutes  needs the GPU, power-sensitive, blocking ONLY on
+#                               a measured regression -- exit 2 (INCONCLUSIVE,
+#                               nothing measured) warns and allows the push, see
+#                               the case block at the end of this file (#176)
 #
 # renv_check must precede test-r: every R suite needs cuasmR loadable, so an
 # out-of-sync library should produce renv's diagnosis, not a confusing testthat

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
       # always 100% of whatever was found, so without it a vanished or renamed
       # suite is invisible. Keep in step with R_SUITES in the Makefile.
       - name: List the suites that will run
-        run: Rscript scripts/audit/run_r_tests.R --list --expect 3
+        run: Rscript scripts/audit/run_r_tests.R --list --expect 4
 
       # Runs the same entry point the pre-push hook runs. No `make` prerequisites
       # are triggered: test-r has none, by design.
@@ -187,9 +187,9 @@ jobs:
           # healthy run. The banner is printed before the per-suite rows.
           n_skip=$(grep 'GPU-free R suites:' test-r.log | grep -oE '[0-9]+ skipped' | grep -oE '^[0-9]+' || echo 0)
           [ -n "$n_skip" ] || n_skip=0
-          echo "suites reporting ok: $n_ok (expect 3) | tests skipped: $n_skip (expect 4)"
-          [ "$n_ok" -eq 3 ] || {
-            echo "::error::Expected 3 suites to report ok, saw $n_ok. Keep in step with R_SUITES in the Makefile."
+          echo "suites reporting ok: $n_ok (expect 4) | tests skipped: $n_skip (expect 4)"
+          [ "$n_ok" -eq 4 ] || {
+            echo "::error::Expected 4 suites to report ok, saw $n_ok. Keep in step with R_SUITES in the Makefile."
             exit 1
           }
           [ "$n_skip" -eq 4 ] || {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
       # Every guard inside run_r_tests.R (--expect, the skip count, the canary) is
       # downstream of it actually running. Empty the Makefile recipe and
       # `make test-r` exits 0; the hook and this job both read that as green and
-      # the canary is never reached. `--list --expect 3` two steps up checks
+      # the canary is never reached. `--list --expect 4` two steps up checks
       # discovery, not execution.
       #
       # So: assert on the gate's own output the same way the restore step asserts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,15 +111,36 @@ right for a deliberate locked evaluation, where measuring nothing must not read
 as success. If a binding signal is ever wanted here, that is #179, and it should
 be decided for the whole gate rather than by tightening one exit code.
 
+Two traps found while wiring those callers up, both of which had turned a
+non-verdict into a verdict:
+
+- **PowerShell 7 eats native exit codes.** `run_locked_eval.ps1` sets
+  `$PSNativeCommandUseErrorActionPreference = $true`, so a non-zero exit from its
+  `wsl.exe … Rscript` call threw `NativeCommandExitException` and skipped its own
+  `$BenchExit = $LASTEXITCODE`, its results record and its `exit $BenchExit`
+  entirely — reporting 1 for *both* FAILED and INCONCLUSIVE, and writing no
+  record for exactly the runs that measured nothing. It is now disabled around
+  that one call and restored immediately after. Measured on pwsh 7.6.3; a no-op
+  on Windows PowerShell 5.1, which never threw.
+- **`Rscript` itself exits 2 when it cannot open the script file.** That is the
+  same code as INCONCLUSIVE, so `make bench` guards on `test -r` before running:
+  a missing or unreadable `bench_regress.R` is an error, not "measured nothing".
+
+Both are the same shape as the bug being fixed — a signal that means "no
+measurement happened" arriving somewhere that reads it as a measurement.
+
 To actually measure the locked configs, lock the clock host-side first (elevated
 Windows shell: `nvidia-smi.exe -lgc 1605,1605`), run
 `Rscript scripts/bench/bench_regress.R --clock-locked 1605`, then release it
 with `nvidia-smi.exe -rgc`.
 
-**`make test-r` runtime.** 117 s of tests on AC, measured 2026-07-31 on the
-RTX 3070 Ti laptop across four suites: `tests/bench_all/test_bench_all.R` 83 s,
-`tests/bench_regress/test_meta.R` 9 s, `tests/bench_regress/test_verdict.R` 9 s
-(added by #176), the `cuasmR` package suite 16 s. The 2026-07-30 three-suite run
+**`make test-r` runtime.** 127 s of tests on AC, measured 2026-07-31 on the
+RTX 3070 Ti laptop across four suites: `tests/bench_all/test_bench_all.R` 80 s,
+`tests/bench_regress/test_meta.R` 8 s, `tests/bench_regress/test_verdict.R` 23 s
+(added by #176; 14 s of it is four end-to-end groups that each start a child R
+process to run the real gate against a throwaway fixture — the price of covering
+the wiring rather than only the decision), the `cuasmR` package suite 15 s. The
+2026-07-30 three-suite run
 was 115 s of tests / 124 s wall on AC and 133 s / 140 s on battery; the wall
 figure predates the plumbing canary, which adds one R startup without changing
 the per-suite total, since the canary is deliberately excluded from it. Both are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,19 +74,58 @@ deterministic first so a doomed push is rejected fast and legibly:
 | `scripts/audit/renv_check.R` | ~2–10 s | yes | no |
 | `make test-r` | ~2 min | yes | no |
 | `make test` | minutes | no (best-effort) | yes |
-| `scripts/bench/bench_regress.R` | minutes | yes | yes |
+| `scripts/bench/bench_regress.R` | minutes | on a measured regression | yes |
 
 `renv_check` precedes `test-r` because every R suite needs `cuasmR` loadable, so
 an out-of-sync library should produce renv's diagnosis rather than a confusing
 testthat error. `make test` precedes `bench_regress.R` because it builds the
 executables that get measured.
 
-**`make test-r` runtime.** 115 s of tests / 124 s wall on AC, measured 2026-07-30
-on the RTX 3070 Ti laptop (the wall figure predates the plumbing canary, which
-adds one R startup — the per-suite total is unaffected, since the canary is
-deliberately excluded from it): `tests/bench_all/test_bench_all.R` 91 s,
-`tests/bench_regress/test_meta.R` 9 s, the `cuasmR` package suite 15 s. On
-battery the same run took 133 s / 140 s.
+**A run that measured nothing warns; it does not block (#176).**
+`bench_regress.R` has three exit codes — `0` PASSED, `1` FAILED (at least one
+measured regression), `2` INCONCLUSIVE (nothing was measured, so nothing is
+certified). The hook renders `2` as a yellow warning and allows the push.
+
+This is a deliberate decision, recorded here because the alternative is
+defensible and someone will propose it. Until #176 the third case did not
+exist: an all-skip run exited 0 and the hook printed "All benchmarks within
+tolerance. Push allowed." having measured zero kernels — which it did on five
+consecutive real pushes, at 7 of 7 skipped. Making that state *blocking* was
+rejected for one reason: the routine case on this laptop is already mostly
+skipped (three configs sit behind a host-side clock lock this hook never
+applies, per #156; throttle takes more whenever the machine is warm), so a
+blocking INCONCLUSIVE would reject ordinary pushes, and its escape hatch —
+`git push --no-verify` — switches off all five steps, including the GPU-free R
+suites that #163 exists to enforce. A warning that gets read beats a block that
+gets bypassed. The honesty requirement is met by the summary line, which now
+always names the fraction measured:
+
+```
+Total: 7 | Measured: 3 | Regressions: 0 | Improvements: 0 | Skipped: 4
+RESULT: PASSED -- 3 of 7 config(s) measured, all within tolerance (4 skipped)
+```
+
+Three callers, one policy each, all reading the same exit code: the hook warns,
+`make bench` warns, and `scripts/probe/run_locked_eval.ps1` propagates it —
+right for a deliberate locked evaluation, where measuring nothing must not read
+as success. If a binding signal is ever wanted here, that is #179, and it should
+be decided for the whole gate rather than by tightening one exit code.
+
+To actually measure the locked configs, lock the clock host-side first (elevated
+Windows shell: `nvidia-smi.exe -lgc 1605,1605`), run
+`Rscript scripts/bench/bench_regress.R --clock-locked 1605`, then release it
+with `nvidia-smi.exe -rgc`.
+
+**`make test-r` runtime.** 117 s of tests on AC, measured 2026-07-31 on the
+RTX 3070 Ti laptop across four suites: `tests/bench_all/test_bench_all.R` 83 s,
+`tests/bench_regress/test_meta.R` 9 s, `tests/bench_regress/test_verdict.R` 9 s
+(added by #176), the `cuasmR` package suite 16 s. The 2026-07-30 three-suite run
+was 115 s of tests / 124 s wall on AC and 133 s / 140 s on battery; the wall
+figure predates the plumbing canary, which adds one R startup without changing
+the per-suite total, since the canary is deliberately excluded from it. Both are
+n=1. Note the totals barely moved while a whole suite was added and
+`test_bench_all.R` swung 91 s → 83 s: run-to-run variance on this mount is
+larger than a 9 s suite, so do not read a single total as a trend.
 
 That battery penalty is only **1.16×**, which is much smaller than it looks like
 it should be: a no-op `Rscript` on this box is **2.1×** slower on battery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,35 @@ historical reference.
   pattern.
 
 ### Fixed
+- **The regression gate no longer reports `PASSED` having measured nothing
+  (#176).** `bench_regress.R` decided its verdict on `regressions > 0L` alone, so
+  a run in which every config skipped printed `RESULT: PASSED -- all benchmarks
+  within tolerance` and exited 0 with zero kernels compared against zero
+  baselines. It did so on five consecutive real pushes at 7 of 7 skipped, and the
+  pre-push hook rendered that as a green "All benchmarks within tolerance. Push
+  allowed." Two effects stack to make the empty run routine rather than
+  occasional: #156 deliberately put three of the seven configs behind a host-side
+  clock lock the hook never applies, and throttle-skip takes the rest whenever
+  the laptop is warm. There is now a third outcome, `INCONCLUSIVE`, with its own
+  exit code (`0` PASSED / `1` FAILED / `2` INCONCLUSIVE), and every verdict line
+  names the fraction measured — `PASSED -- 3 of 7 config(s) measured, all within
+  tolerance (4 skipped)`, which is the sentence the old one should have been. A
+  measured regression still outranks everything: 1 config measured and regressed
+  is `FAILED`, not `INCONCLUSIVE`. Configs belonging to a kernel with no built
+  executable are now counted as skipped instead of vanishing from the
+  denominator, so an unbuilt corpus reports `0 of 7`, not `Total: 0` followed by
+  a pass. **On all-skip the hook warns and allows the push** — a deliberate
+  choice, argued in `AGENTS.md` next to the hook step table: blocking would
+  reject ordinary pushes on this machine and its escape hatch, `git push
+  --no-verify`, disables all five hook steps including the #163 R suites. All
+  three callers read the same code: hook warns, `make bench` warns,
+  `run_locked_eval.ps1` propagates. Proven both ways on real runs before landing
+  — an all-skip (`Total: 2 | Measured: 0` → INCONCLUSIVE, exit 2, where the same
+  command on the parent commit printed PASSED and exited 0) and a live one
+  (`Total: 7 | Measured: 3` → PASSED, exit 0). The verdict is a pure function of
+  four counters and is unit-tested by the new
+  `tests/bench_regress/test_verdict.R`, which the #163 gate discovers
+  automatically; `R_SUITES` and the `tests.yml` denominators go 3 → 4.
 - **Retired the dead `tests/bench_regress/test_parser.R` (#171).** All 14 of its
   `test_that` groups had been erroring since `caeca97` (2026-06-02), which removed
   the `.pick_line` / `.parse_line` pair it exercises in favour of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,17 @@ historical reference.
   reject ordinary pushes on this machine and its escape hatch, `git push
   --no-verify`, disables all five hook steps including the #163 R suites. All
   three callers read the same code: hook warns, `make bench` warns,
-  `run_locked_eval.ps1` propagates. Proven both ways on real runs before landing
+  `run_locked_eval.ps1` propagates. Two of those callers needed repairing before
+  that sentence was true, and both failed the same way the gate did — treating
+  "no measurement happened" as a measurement. `run_locked_eval.ps1` sets
+  `$PSNativeCommandUseErrorActionPreference`, so on PowerShell 7 any non-zero
+  exit from its `wsl.exe … Rscript` call threw before `$BenchExit =
+  $LASTEXITCODE` ran: it reported 1 for both FAILED and INCONCLUSIVE and wrote no
+  results record at all for the runs that measured nothing (measured on pwsh
+  7.6.3; a no-op on PS 5.1). And `Rscript` exits 2 when it cannot open the script
+  file, which is INCONCLUSIVE's code, so `make bench` now guards on `test -r`
+  first — a missing gate is an error, not an empty measurement.
+  Proven both ways on real runs before landing
   — an all-skip (`Total: 2 | Measured: 0` → INCONCLUSIVE, exit 2, where the same
   command on the parent commit printed PASSED and exited 0) and a live one
   (`Total: 7 | Measured: 3` → PASSED, exit 0). The verdict is a pure function of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,11 @@ Steps 1, 2, 3 and 5 block the push on failure; step 4 is best-effort. Steps 1–
 need no GPU, so on a machine with no card attached they still run — and step 3
 is the substantial one among them.
 
+Step 5 has a third outcome that is not a failure: if it measured nothing at all
+(every config skipped), it reports `INCONCLUSIVE`, warns, and allows the push
+(#176). Read that warning — it means performance was not checked, not that it
+was checked and found fine.
+
 **Bypass** (for WIP or when you know baseline is stale):
 ```bash
 git push --no-verify

--- a/Makefile
+++ b/Makefile
@@ -258,8 +258,20 @@ renv-check:
 verify:
 	@$(RSCRIPT) scripts/verify_setup.R
 
+# Exit 2 is INCONCLUSIVE -- bench_regress.R measured nothing, so it certifies
+# nothing (#176). Same policy as .githooks/pre-push: say so loudly, do not turn
+# it into a hard error. Without this branch `make bench` would newly fail
+# whenever the laptop is warm, which is not what the third exit code is for.
+# Exit 1 (a measured regression) still fails the target.
 bench:
-	@$(RSCRIPT) scripts/bench/bench_regress.R
+	@$(RSCRIPT) scripts/bench/bench_regress.R; rc=$$?; \
+	if [ $$rc -eq 2 ]; then \
+	  echo ""; \
+	  echo "WARNING: nothing was measured -- see the INCONCLUSIVE line above."; \
+	  echo "Exit 2 reported as a warning; performance was NOT verified."; \
+	  exit 0; \
+	fi; \
+	exit $$rc
 
 # Full-corpus "run everything" pass (#124). Builds the whole corpus, then
 # runs every bench and records every result + metadata to

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,19 @@ verify:
 # it into a hard error. Without this branch `make bench` would newly fail
 # whenever the laptop is warm, which is not what the third exit code is for.
 # Exit 1 (a measured regression) still fails the target.
+#
+# The `test -r` guard is load-bearing, not decoration: `Rscript` itself exits 2
+# when it cannot open the script file ("Fatal error: cannot open file"), which is
+# the same code bench_regress.R uses for INCONCLUSIVE. Without the guard, a
+# renamed, deleted or unreadable bench_regress.R would be laundered into
+# "nothing was measured" and `make bench` would report success having run no R at
+# all. A missing gate is an error here, not a warning.
 bench:
+	@test -r scripts/bench/bench_regress.R || { \
+	  echo "ERROR: scripts/bench/bench_regress.R is missing or unreadable."; \
+	  echo "Nothing was run. This is not the same as measuring nothing."; \
+	  exit 1; \
+	}
 	@$(RSCRIPT) scripts/bench/bench_regress.R; rc=$$?; \
 	if [ $$rc -eq 2 ]; then \
 	  echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ test: cubins $(GEMM_BENCH) $(REDUCTIONS_BENCH) $(ELEMENTWISE_BENCH) $(REGRESS_BE
 # Without it "all discovered suites passed" is a ratio against whatever was
 # discovered and is therefore always 100% -- delete every suite and the gate
 # still goes green. Bump this deliberately when adding or removing a suite.
-R_SUITES ?= 3
+R_SUITES ?= 4
 
 test-r:
 	@$(RSCRIPT) scripts/audit/run_r_tests.R --expect $(R_SUITES)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ make reproduce          # setup + verify + build + bench-vs-baselines
 `make reproduce` chains `setup` (renv restore + cuasmR install),
 `verify` (env check), `all` (compile every cubin + bench), `bench`
 (run benches and compare against `data/baselines.json`; this stage
-prints `RESULT: PASSED -- all benchmarks within tolerance`), and
+prints `RESULT: PASSED -- N of M config(s) measured, all within
+tolerance`, or `INCONCLUSIVE` if the GPU state let it measure nothing —
+see the hook step table in [`AGENTS.md`](AGENTS.md)), and
 `figures` (regenerate `docs/figures/`). The run finishes with the
 `Full reproduction complete` banner. The pre-push hook calls the same
 regression check. Build entry points are documented in

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,8 +23,11 @@ The `make reproduce` target runs:
 
 A clean run on a healthy GPU ends with `RESULT: PASSED -- N of M
 config(s) measured, all within tolerance`. If the GPU state let it
-measure nothing at all, it ends with `RESULT: INCONCLUSIVE` and exit
-code 2 instead — a warning, not a failure (#176). The pre-push git hook calls the same
+measure nothing at all, it ends with `RESULT: INCONCLUSIVE` instead:
+the script exits 2, and `make bench` reports that as a warning and
+still exits 0, so `make reproduce` continues (#176). Read the RESULT
+line — a run that measured nothing is not a run that found nothing
+wrong. The pre-push git hook calls the same
 regression check, plus checks this command does not: a README link
 audit and the GPU-free R test suites (`make test-r`, #163). The renv
 sync check runs in both — `make reproduce` reaches it via `make setup`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -21,8 +21,10 @@ The `make reproduce` target runs:
 3. `make all`     — compile every kernel `.cu` to `.cubin` + every bench `.cu` to executable
 4. `make bench`   — run all benches, compare against `data/baselines.json`
 
-A clean run on a healthy GPU ends with `RESULT: PASSED -- all
-benchmarks within tolerance`. The pre-push git hook calls the same
+A clean run on a healthy GPU ends with `RESULT: PASSED -- N of M
+config(s) measured, all within tolerance`. If the GPU state let it
+measure nothing at all, it ends with `RESULT: INCONCLUSIVE` and exit
+code 2 instead — a warning, not a failure (#176). The pre-push git hook calls the same
 regression check, plus checks this command does not: a README link
 audit and the GPU-free R test suites (`make test-r`, #163). The renv
 sync check runs in both — `make reproduce` reaches it via `make setup`.
@@ -141,15 +143,28 @@ make compare-reference    # project baselines vs local reference baselines
 
 Equivalent to `Rscript scripts/bench/bench_regress.R`. Each kernel
 runs once, GPU + host state is captured before and after, and the
-result is compared against the recorded baseline. Three verdicts:
+result is compared against the recorded baseline. Three per-config
+verdicts:
 
 - `OK` — within tolerance (default 10%, per-config override
   available)
 - `IMPROVED` / `REGRESSION` — outside tolerance, real change
 - `SKIPPED` — measurement-time GPU state was unfair (thermal
-  throttle, sw power cap, etc.); the run is dropped, not failed.
+  throttle, sw power cap, etc.), or the config is clock-locked and no
+  `--clock-locked` was given; the run is dropped, not failed.
   See the baselines schema in `data/baselines.json` and `CHANGELOG.md`
   for the fair-run capture policy.
+
+And three run-level verdicts, one per exit code (#176):
+
+- `PASSED` (0) — at least one config was measured and none regressed.
+  The line names the fraction: `3 of 7 config(s) measured`.
+- `FAILED` (1) — at least one measured regression.
+- `INCONCLUSIVE` (2) — **nothing** was measured, so nothing is
+  certified. Routine on this laptop: three configs sit behind a
+  host-side clock lock (#156) and throttle takes more when it is warm.
+  The pre-push hook and `make bench` report it as a warning and do not
+  block; `scripts/probe/run_locked_eval.ps1` propagates it.
 
 To list recorded baselines without running:
 

--- a/scripts/bench/bench_regress.R
+++ b/scripts/bench/bench_regress.R
@@ -277,7 +277,11 @@ measure_clock_locked <- function(exe, cfg_args, baseline_cfg, clock_lock,
 #   scripts/probe/run_locked_eval.ps1
 #                                 propagates it verbatim, which is right: a
 #                                 deliberate locked evaluation that measured
-#                                 nothing must not report success.
+#                                 nothing must not report success. That script
+#                                 had to be repaired to do so -- PowerShell 7
+#                                 was throwing on any non-zero native exit and
+#                                 skipping its own capture, so it reported 1 for
+#                                 both outcomes and wrote no record at all.
 #
 # `measured` counts configs that reached a verdict other than SKIPPED. CRASH
 # and NO_DATA count as measured and also land in `regressions`, so they report

--- a/scripts/bench/bench_regress.R
+++ b/scripts/bench/bench_regress.R
@@ -241,6 +241,69 @@ measure_clock_locked <- function(exe, cfg_args, baseline_cfg, clock_lock,
 # CRASH / SKIPPED (unfair GPU state) / NO_DATA / REGRESSION / OK / IMPROVED.
 
 # ----------------------------------------------------------------------
+# Run verdict (issue #176)
+#
+# The verdict used to branch on `regressions > 0L` alone, so a run in which
+# every config SKIPPED printed
+#
+#   RESULT: PASSED -- all benchmarks within tolerance
+#
+# and exited 0 having compared nothing against anything. Observed on five
+# consecutive real pushes at 7 of 7 skipped: #156 put three configs behind a
+# host-side clock lock that the pre-push hook never applies, and throttle-skip
+# took the remaining four. "No regressions were found" and "no measurement was
+# taken" are the same number, and only one of them is good news.
+#
+# Three outcomes, three exit codes:
+#
+#   0  PASSED        at least one config measured, none of them regressed
+#   1  FAILED        at least one measured regression
+#   2  INCONCLUSIVE  nothing was measured; this gate certifies nothing
+#
+# A measured regression outranks the empty-run case: if something was measured
+# and it regressed, that is real information, however many of its neighbours
+# skipped.
+#
+# INCONCLUSIVE is a distinct code rather than a failure because the *caller*
+# owns the policy, and the three callers want different things:
+#
+#   .githooks/pre-push            warns and allows the push (deliberate; see
+#                                 the hook step table in AGENTS.md). Blocking
+#                                 would reject most pushes on this laptop, and
+#                                 its escape hatch -- git push --no-verify --
+#                                 switches off all five hook steps including
+#                                 the GPU-free R gate (#163).
+#   make bench                    same policy as the hook: warn, exit 0.
+#   scripts/probe/run_locked_eval.ps1
+#                                 propagates it verbatim, which is right: a
+#                                 deliberate locked evaluation that measured
+#                                 nothing must not report success.
+#
+# `measured` counts configs that reached a verdict other than SKIPPED. CRASH
+# and NO_DATA count as measured and also land in `regressions`, so they report
+# FAILED -- they can never make an empty run look green.
+# ----------------------------------------------------------------------
+summarise_verdict <- function(total, measured, regressions, skipped) {
+  if (regressions > 0L) {
+    return(list(status = "FAILED", exit = 1L,
+                msg = sprintf(
+                  "FAILED -- %d regression(s) detected (%d of %d config(s) measured)",
+                  regressions, measured, total)))
+  }
+  if (measured < 1L) {
+    return(list(status = "INCONCLUSIVE", exit = 2L,
+                msg = sprintf(
+                  paste0("INCONCLUSIVE -- 0 of %d config(s) measured (%d skipped); ",
+                         "nothing was verified"),
+                  total, skipped)))
+  }
+  list(status = "PASSED", exit = 0L,
+       msg = sprintf(
+         "PASSED -- %d of %d config(s) measured, all within tolerance (%d skipped)",
+         measured, total, skipped))
+}
+
+# ----------------------------------------------------------------------
 # main
 # ----------------------------------------------------------------------
 main <- function() {
@@ -297,9 +360,29 @@ main <- function() {
   cat(strrep("=", 70), "\n")
 
   regressions <- 0L; improvements <- 0L; skipped <- 0L; total <- 0L
+  # `measured` is the count that decides PASSED vs INCONCLUSIVE (#176).
+  measured <- 0L
 
   # Reserved keys at the kernel-entry level that are not config names.
   RESERVED_KEYS <- c("exe")
+
+  # Fold one config's verdict into the run counters. `<<-` targets main()'s
+  # locals. The two call sites below (clock-locked and direct) each carried
+  # their own copy of this ladder, so #176 would have had to add `measured`
+  # in two places and every later bucket in two more.
+  tally <- function(verdict) {
+    if (isTRUE(verdict$skipped)) {
+      skipped <<- skipped + 1L
+      return(invisible(NULL))
+    }
+    measured <<- measured + 1L
+    if (verdict$is_reg) {
+      regressions <<- regressions + 1L
+    } else if (grepl("IMPROVED", verdict$msg, fixed = TRUE)) {
+      improvements <<- improvements + 1L
+    }
+    invisible(NULL)
+  }
 
   # Print one-line GPU state header so the user can see
   # whether the run started under unfair conditions.
@@ -320,14 +403,22 @@ main <- function() {
 
   for (kernel_path in names(kernels)) {
     entry <- kernels[[kernel_path]]
+    cfg_names <- setdiff(names(entry), RESERVED_KEYS)
     # `exe` override from baselines schema: use if present, else heuristic.
     exe <- if (!is.null(entry$exe)) entry$exe else find_executable(kernel_path)
     if (is.null(exe) || !file.exists(exe)) {
-      cat(sprintf("\n%s\n  SKIP -- executable not found (try: make benches)\n",
-                  kernel_path))
+      # Count the configs that cannot run (#176). This branch used to `next`
+      # without touching a counter, so an unbuilt corpus reported `Total: 0`
+      # -- the denominator disappeared along with the measurement, and the
+      # run still exited 0. Counting them keeps `total` the number of configs
+      # in baselines.json rather than the number we happened to reach.
+      cat(sprintf(
+        "\n%s\n  SKIPPED -- executable not found (try: make benches) [%d config(s)]\n",
+        kernel_path, length(cfg_names)))
+      total   <- total   + length(cfg_names)
+      skipped <- skipped + length(cfg_names)
       next
     }
-    cfg_names <- setdiff(names(entry), RESERVED_KEYS)
     for (cfg in cfg_names) {
       total <- total + 1L
       cfg_args <- strsplit(cfg, "_", fixed = TRUE)[[1]]
@@ -371,10 +462,7 @@ main <- function() {
                                     default_valid_when = .default_vw)
         cat(sprintf("\n%s [%s] (clock-locked %d MHz, median of %d)\n  %s\n",
                     kernel_path, cfg, cl, CLOCK_LOCK_SAMPLES, verdict$msg))
-        if (isTRUE(verdict$skipped))      skipped <- skipped + 1L
-        else if (verdict$is_reg)          regressions <- regressions + 1L
-        else if (grepl("IMPROVED", verdict$msg, fixed = TRUE))
-                                          improvements <- improvements + 1L
+        tally(verdict)
         next
       }
 
@@ -389,22 +477,17 @@ main <- function() {
                                   default_valid_when = .default_vw)
 
       cat(sprintf("\n%s [%s]\n  %s\n", kernel_path, cfg, verdict$msg))
-      if (isTRUE(verdict$skipped)) skipped <- skipped + 1L
-      else if (verdict$is_reg)     regressions <- regressions + 1L
-      else if (grepl("IMPROVED", verdict$msg, fixed = TRUE)) improvements <- improvements + 1L
+      tally(verdict)
     }
   }
 
   cat("\n", strrep("=", 70), "\n", sep = "")
-  cat(sprintf("  Total: %d | Regressions: %d | Improvements: %d | Skipped: %d\n",
-              total, regressions, improvements, skipped))
-  if (regressions > 0L) {
-    cat(sprintf("  RESULT: FAILED -- %d regression(s) detected\n", regressions))
-    quit(status = 1)
-  } else {
-    cat("  RESULT: PASSED -- all benchmarks within tolerance\n")
-    quit(status = 0)
-  }
+  cat(sprintf(
+    "  Total: %d | Measured: %d | Regressions: %d | Improvements: %d | Skipped: %d\n",
+    total, measured, regressions, improvements, skipped))
+  v <- summarise_verdict(total, measured, regressions, skipped)
+  cat(sprintf("  RESULT: %s\n", v$msg))
+  quit(status = v$exit)
 }
 
 if (sys.nframe() == 0L) main()

--- a/scripts/probe/run_locked_eval.ps1
+++ b/scripts/probe/run_locked_eval.ps1
@@ -222,11 +222,35 @@ try {
   "cmd: $($wslCmd -join ' ')" | Add-Content $LogPath
   "" | Add-Content $LogPath
 
-  # Stream stdout+stderr line-by-line into the log AND the console.
-  & $wslCmd[0] $wslCmd[1..($wslCmd.Length - 1)] 2>&1 | ForEach-Object {
-    $_ | Tee-Object -FilePath $LogPath -Append | Write-Host
+  # A non-zero bench exit is DATA here, not an error (#176). bench_regress.R
+  # exits 1 on a measured regression and 2 when it measured nothing at all, and
+  # both belong in $BenchExit, in bench_exit_code, in the results record and in
+  # this script's own exit status.
+  #
+  # $PSNativeCommandUseErrorActionPreference (set at the top of this file) makes
+  # PS 7 throw NativeCommandExitException on any non-zero native exit, which
+  # aborts the pipeline below before $LASTEXITCODE is ever read: the capture, the
+  # post-restore snapshot, the JSONL record and `exit $BenchExit` are all skipped
+  # and the script exits 1. That collapses INCONCLUSIVE into the code that means
+  # FAILED, and drops the record for exactly the runs that measured nothing.
+  # Measured on pwsh 7.6.3: native exit 2 -> script exit 1, no record written.
+  # It went unnoticed while the script only ever emitted 0 and 1.
+  #
+  # So disable it for this one call and read $LASTEXITCODE by hand. Restored
+  # immediately after, so nvidia-smi.exe -rgc in the finally block keeps throwing
+  # on failure. No-op on PS 5.1, which never threw and always propagated.
+  $prevNativeEap = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    # Stream stdout+stderr line-by-line into the log AND the console.
+    & $wslCmd[0] $wslCmd[1..($wslCmd.Length - 1)] 2>&1 | ForEach-Object {
+      $_ | Tee-Object -FilePath $LogPath -Append | Write-Host
+    }
+    $BenchExit = $LASTEXITCODE
   }
-  $BenchExit = $LASTEXITCODE
+  finally {
+    $PSNativeCommandUseErrorActionPreference = $prevNativeEap
+  }
   "" | Add-Content $LogPath
   "bench_exit_code: $BenchExit" | Add-Content $LogPath
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,6 +13,7 @@ These files validate hardware assumptions, fragment layouts, and race conditions
 | `flash_attention/verify_wmma_layout.cu` | WMMA accumulator fragment layout (sm_86) |
 | `bench_all/test_bench_all.R` | GPU-free unit tests for `scripts/bench/bench_all.R` and `bench_all_collect.R` (#124, #152): corpus discovery, spec merge, the taxonomy×regime planner, status classification, summary aggregation, markdown render |
 | `bench_regress/test_meta.R`   | Metadata tests for `scripts/bench/bench_meta.R` — throttle-reason decode and `classify_meta` policies against canned snapshots; the live-capture smoke test skips without `nvidia-smi` |
+| `bench_regress/test_verdict.R` | The run verdict in `scripts/bench/bench_regress.R` (#176): PASSED / FAILED / INCONCLUSIVE and their three exit codes, pinning that an all-skipped run can never print "all benchmarks within tolerance" again |
 
 Build any CUDA test individually with the same `nvcc` commands used for production kernels.
 
@@ -24,7 +25,7 @@ The GPU-free R suites are a **pre-push gate** (#163). Run all of them with:
 make test-r
 ```
 
-That covers the two files above plus the `cuasmR` package's own testthat suite
+That covers the three R files above plus the `cuasmR` package's own testthat suite
 (`R/cuasmR/tests/testthat/`), which is not under `tests/` but is gated the same
 way — it holds the only characterization test for the parser that
 `scripts/bench/bench_regress.R` calls in the regression gate.
@@ -35,14 +36,18 @@ To see what would run without running it:
 Rscript scripts/audit/run_r_tests.R --list
 ```
 
-Discovery is by glob, so a new `tests/**/test_*.R` is gated the day it lands —
-no manifest to forget to update.
+Discovery is by glob, so a new `tests/**/test[-_]*.R` is gated the day it lands —
+no manifest to forget to update. The expected suite count is supplied from
+outside the runner (`R_SUITES` in the `Makefile`, `--expect` in `tests.yml`), so
+adding one is a deliberate two-line edit rather than something that happens
+silently.
 
 Two notes on reading the output:
 
-- Each suite ends with an unconditional `cat("All ... tests passed.")`. That line
-  prints regardless of the result. **The exit status is the verdict**, which is
-  why the runner reports its own table.
+- `test_meta.R` ends with an unconditional `cat("All ... tests passed.")`. That
+  line prints regardless of the result. **The exit status is the verdict**,
+  which is why the runner reports its own table. Do not add such a line to a new
+  suite — `test_verdict.R` deliberately has none.
 - Three of the `cuasmR` roundtrip tests skip unless `kernels/tutorial/vector_add.sm_86.cubin`
   has been built (it is gitignored) *and* `nvdisasm` is on `PATH`. They therefore
   always skip in CI. Run `make cubins` locally for that coverage.

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,10 +44,14 @@ silently.
 
 Two notes on reading the output:
 
-- `test_meta.R` ends with an unconditional `cat("All ... tests passed.")`. That
-  line prints regardless of the result. **The exit status is the verdict**,
-  which is why the runner reports its own table. Do not add such a line to a new
-  suite — `test_verdict.R` deliberately has none.
+- `test_meta.R` ends with an unconditional `cat("All ... tests passed.")` — a
+  line that asserts success without checking it. Under the runner's `Rscript
+  <file>` form a failing `test_that` aborts the script before it prints, so it
+  is currently harmless; under `testthat::test_file()` it prints even when every
+  group errored, which is how the retired `test_parser.R` looked green for 58
+  days (#171). **The exit status is the verdict**, which is why the runner
+  reports its own table rather than echoing what a suite claims about itself. Do
+  not add such a line to a new suite — `test_verdict.R` deliberately has none.
 - Three of the `cuasmR` roundtrip tests skip unless `kernels/tutorial/vector_add.sm_86.cubin`
   has been built (it is gitignored) *and* `nvdisasm` is on `PATH`. They therefore
   always skip in CI. Run `make cubins` locally for that coverage.

--- a/tests/bench_regress/test_verdict.R
+++ b/tests/bench_regress/test_verdict.R
@@ -1,0 +1,160 @@
+# tests/bench_regress/test_verdict.R
+#
+# GPU-free unit tests for the run verdict in scripts/bench/bench_regress.R
+# (issue #176).
+#
+# The bug these pin: the verdict branched on `regressions > 0L` alone, so a
+# run in which every config SKIPPED printed "PASSED -- all benchmarks within
+# tolerance" and exited 0 having measured nothing. It did that on five
+# consecutive real pushes at 7 of 7 skipped, and the pre-push hook rendered it
+# as a green "All benchmarks within tolerance. Push allowed."
+#
+# summarise_verdict() is a pure function of four counters, so the whole
+# decision is testable here with no GPU, no baselines file and no bench
+# executables. What is NOT covered here is the wiring -- whether main() feeds
+# it the right counters. That needs a real run; the two recorded on PR for
+# #176 are an all-skip (Total 2, Measured 0 -> INCONCLUSIVE, exit 2) and a
+# live one (Total 7, Measured 3 -> PASSED, exit 0).
+#
+# Run:
+#   Rscript tests/bench_regress/test_verdict.R
+
+library(testthat)
+
+# Source bench_regress.R for its functions. main() is guarded by
+# `if (sys.nframe() == 0L) main()`, so sourcing runs no benchmarks.
+#
+# Two relative candidates only, both resolved from the repo root, which is
+# where scripts/audit/run_r_tests.R runs its children. The sibling suites end
+# this list with a hardcoded /mnt/d/dev/p/bare-metal/... path that makes them
+# pass on one machine and fail everywhere else (#173) -- not repeated here.
+.candidates <- c(
+  "scripts/bench/bench_regress.R",
+  file.path(getwd(), "scripts", "bench", "bench_regress.R"))
+.src <- NULL
+for (.p in .candidates) if (file.exists(.p)) { .src <- .p; break }
+if (is.null(.src)) {
+  stop("can't find scripts/bench/bench_regress.R -- run this from the repo root")
+}
+suppressMessages(source(.src))
+
+# ---- the reported bug --------------------------------------------------
+
+test_that("an all-skipped run is INCONCLUSIVE, not PASSED", {
+  # The #176 observation, verbatim: 7 configs, every one skipped.
+  v <- summarise_verdict(total = 7L, measured = 0L, regressions = 0L,
+                         skipped = 7L)
+  expect_equal(v$status, "INCONCLUSIVE")
+  expect_equal(v$exit, 2L)
+})
+
+test_that("an all-skipped run never claims benchmarks are within tolerance", {
+  # The precise sentence the operator read as a pass. It must not survive
+  # anywhere in the message, whatever else the wording becomes.
+  v <- summarise_verdict(7L, 0L, 0L, 7L)
+  expect_false(grepl("within tolerance", v$msg, fixed = TRUE))
+  expect_false(grepl("PASSED", v$msg, fixed = TRUE))
+})
+
+test_that("an all-skipped run says what it did not do", {
+  v <- summarise_verdict(7L, 0L, 0L, 7L)
+  expect_match(v$msg, "0 of 7", fixed = TRUE)
+  expect_match(v$msg, "nothing was verified", fixed = TRUE)
+})
+
+test_that("an all-skipped run does not exit 0", {
+  # The whole failure was a zero exit status: the hook branches on it.
+  expect_gt(summarise_verdict(7L, 0L, 0L, 7L)$exit, 0L)
+})
+
+# ---- the empty corpus --------------------------------------------------
+
+test_that("zero configs is INCONCLUSIVE, not a vacuous pass", {
+  # No baselines matched, or nothing was built: 0/0 is not a clean run.
+  v <- summarise_verdict(0L, 0L, 0L, 0L)
+  expect_equal(v$status, "INCONCLUSIVE")
+  expect_equal(v$exit, 2L)
+})
+
+# ---- the healthy run ---------------------------------------------------
+
+test_that("a fully measured clean run is PASSED and exits 0", {
+  v <- summarise_verdict(7L, 7L, 0L, 0L)
+  expect_equal(v$status, "PASSED")
+  expect_equal(v$exit, 0L)
+  expect_match(v$msg, "within tolerance", fixed = TRUE)
+})
+
+test_that("a partly measured clean run states the fraction it measured", {
+  # The routine case on this laptop: some configs behind a clock lock the
+  # hook never applies (#156), some lost to throttle. It is a pass, but a
+  # pass over 3 configs must not read like a pass over 7.
+  v <- summarise_verdict(7L, 3L, 0L, 4L)
+  expect_equal(v$status, "PASSED")
+  expect_equal(v$exit, 0L)
+  expect_match(v$msg, "3 of 7", fixed = TRUE)
+  expect_match(v$msg, "4 skipped", fixed = TRUE)
+})
+
+test_that("one measured config is enough to be conclusive", {
+  # The floor is one: measuring something is the difference the verdict
+  # turns on, not measuring most things.
+  v <- summarise_verdict(7L, 1L, 0L, 6L)
+  expect_equal(v$status, "PASSED")
+  expect_equal(v$exit, 0L)
+})
+
+test_that("improvements do not change the verdict", {
+  # `improvements` is reported in the counts line but is deliberately not an
+  # argument here: a faster kernel is still a pass.
+  expect_equal(summarise_verdict(2L, 2L, 0L, 0L)$status, "PASSED")
+})
+
+# ---- regressions outrank everything ------------------------------------
+
+test_that("a measured regression is FAILED and exits 1", {
+  v <- summarise_verdict(7L, 7L, 2L, 0L)
+  expect_equal(v$status, "FAILED")
+  expect_equal(v$exit, 1L)
+  expect_match(v$msg, "2 regression", fixed = TRUE)
+})
+
+test_that("a regression outranks a mostly-skipped run", {
+  # 1 measured, 6 skipped, and the one measured config regressed. That is
+  # real information: FAILED, not INCONCLUSIVE.
+  v <- summarise_verdict(7L, 1L, 1L, 6L)
+  expect_equal(v$status, "FAILED")
+  expect_equal(v$exit, 1L)
+})
+
+test_that("FAILED still reports how much was measured", {
+  # A regression found in 1 of 7 configs is weaker evidence than one found
+  # in 7 of 7, and the message has to let the reader tell them apart.
+  expect_match(summarise_verdict(7L, 1L, 1L, 6L)$msg, "1 of 7", fixed = TRUE)
+})
+
+# ---- the exit codes are the interface ----------------------------------
+
+test_that("the three outcomes have three distinct exit codes", {
+  # .githooks/pre-push and scripts/probe/run_locked_eval.ps1 both branch on
+  # these numbers. Collapsing any two would silently change hook policy.
+  codes <- c(
+    passed       = summarise_verdict(7L, 7L, 0L, 0L)$exit,
+    failed       = summarise_verdict(7L, 7L, 1L, 0L)$exit,
+    inconclusive = summarise_verdict(7L, 0L, 0L, 7L)$exit)
+  expect_equal(unname(codes), c(0L, 1L, 2L))
+  expect_equal(length(unique(codes)), 3L)
+})
+
+test_that("every verdict carries a status, an exit code and a message", {
+  for (v in list(summarise_verdict(7L, 7L, 0L, 0L),
+                 summarise_verdict(7L, 7L, 1L, 0L),
+                 summarise_verdict(7L, 0L, 0L, 7L))) {
+    expect_true(is.character(v$status) && nzchar(v$status))
+    expect_true(is.numeric(v$exit))
+    expect_true(is.character(v$msg) && nzchar(v$msg))
+    # The RESULT line is printed as "RESULT: <msg>", so the message has to
+    # start with the status word or the two disagree on screen.
+    expect_true(startsWith(v$msg, v$status))
+  }
+})

--- a/tests/bench_regress/test_verdict.R
+++ b/tests/bench_regress/test_verdict.R
@@ -158,3 +158,94 @@ test_that("every verdict carries a status, an exit code and a message", {
     expect_true(startsWith(v$msg, v$status))
   }
 })
+
+# ---- end-to-end: the wiring, not just the decision ---------------------
+#
+# Everything above tests summarise_verdict() in isolation. That is not enough on
+# its own: the verdict function could be perfect and never consulted, or fed the
+# wrong counters, and every group above would still pass. #176 was a wiring bug
+# -- the decision code was three lines and they were all reachable.
+#
+# So these run the real script as a subprocess against a throwaway repo: a
+# renv.lock (the marker REPO_ROOT walks up to), a data/baselines.json, and a copy
+# of bench_regress.R. No GPU, no nvcc, no built corpus -- the "benchmark" is a
+# shell script printing one bench-shaped line, and the fixture switches off the
+# fairness check (default_valid_when: require_no_throttle false) so the result
+# does not depend on what this machine's GPU happens to be doing at the time.
+#
+# The child runs with the working directory left at the repo root so that the
+# repo's .Rprofile activates renv and cuasmR is loadable; REPO_ROOT comes from
+# the script's own path, which is inside the fixture.
+
+.fixture_root <- function(throughput = NULL, baseline_gflops = 1000) {
+  root <- file.path(tempfile("bench_regress_fixture"))
+  dir.create(file.path(root, "scripts", "bench"), recursive = TRUE)
+  dir.create(file.path(root, "data"), recursive = TRUE)
+  # REPO_ROOT walks up until it finds .git or renv.lock.
+  file.create(file.path(root, "renv.lock"))
+  file.copy(.src, file.path(root, "scripts", "bench", "bench_regress.R"))
+
+  # throughput = NULL means "leave the executable missing", which is the
+  # unbuilt-corpus case: the configs must still be counted.
+  exe <- file.path(root, "fake_bench")
+  if (!is.null(throughput)) {
+    writeLines(c("#!/bin/sh",
+                 sprintf('echo "  fixture 1.000 ms  %s GFLOPS"', throughput)),
+               exe)
+    Sys.chmod(exe, "0755")
+  }
+
+  baselines <- list(
+    recorded_date = "fixture",
+    platform = "fixture",
+    default_valid_when = list(require_no_throttle = FALSE),
+    kernels = list(`kernels/fixture/fake.cu` = list(
+      exe = exe,
+      `1_2` = list(ms = 1.0, gflops = baseline_gflops))))
+  writeLines(jsonlite::toJSON(baselines, auto_unbox = TRUE, pretty = TRUE),
+             file.path(root, "data", "baselines.json"))
+  root
+}
+
+.run_gate <- function(root) {
+  rscript <- file.path(R.home("bin"), "Rscript")
+  out <- suppressWarnings(system2(
+    rscript, file.path(root, "scripts", "bench", "bench_regress.R"),
+    stdout = TRUE, stderr = TRUE))
+  status <- attr(out, "status")
+  list(status = if (is.null(status)) 0L else as.integer(status),
+       text = paste(out, collapse = "\n"))
+}
+
+test_that("end to end: a run that skips everything exits 2 and says INCONCLUSIVE", {
+  # This is #176 itself. Against the code as it was, this exits 0 and prints
+  # "PASSED -- all benchmarks within tolerance".
+  r <- .run_gate(.fixture_root(throughput = NULL))
+  expect_equal(r$status, 2L)
+  expect_match(r$text, "INCONCLUSIVE", fixed = TRUE)
+  expect_false(grepl("within tolerance", r$text, fixed = TRUE))
+})
+
+test_that("end to end: configs of an unbuilt kernel stay in the denominator", {
+  # The emptier version of the same bug: the missing-executable branch used to
+  # skip the whole kernel before any counter moved, reporting `Total: 0`.
+  r <- .run_gate(.fixture_root(throughput = NULL))
+  expect_match(r$text, "Total: 1", fixed = TRUE)
+  expect_match(r$text, "Measured: 0", fixed = TRUE)
+  expect_match(r$text, "0 of 1", fixed = TRUE)
+})
+
+test_that("end to end: a config that measures cleanly exits 0 and is counted", {
+  r <- .run_gate(.fixture_root(throughput = 1000))
+  expect_equal(r$status, 0L)
+  expect_match(r$text, "Measured: 1", fixed = TRUE)
+  expect_match(r$text, "1 of 1 config(s) measured", fixed = TRUE)
+})
+
+test_that("end to end: a measured regression exits 1", {
+  # Half of baseline, far outside the 10% default tolerance.
+  r <- .run_gate(.fixture_root(throughput = 500))
+  expect_equal(r$status, 1L)
+  expect_match(r$text, "FAILED", fixed = TRUE)
+  expect_match(r$text, "Measured: 1", fixed = TRUE)
+})


### PR DESCRIPTION
## What was wrong

`scripts/bench/bench_regress.R` decided its verdict on `regressions > 0L` alone, so a run in
which every config `SKIPPED` printed

```
Total: 7 | Regressions: 0 | Improvements: 0 | Skipped: 7
RESULT: PASSED -- all benchmarks within tolerance
```

and exited 0 having compared nothing against anything. The pre-push hook rendered that as a
green *"All benchmarks within tolerance. Push allowed."* on five consecutive real pushes.

The empty run is structural, not occasional. #156 deliberately put three of the seven configs
behind a host-side clock lock the hook never applies, so they skip on every ordinary push by
design; throttle-skip takes the rest whenever the laptop is warm.

There was a second, emptier version of the same bug: a kernel whose executable is not built
`next`ed out of the loop **before** the counter increments, so an unbuilt corpus reported
`Total: 0` and still called it a pass.

## What changed

Three outcomes, three exit codes — `0` PASSED, `1` FAILED, `2` INCONCLUSIVE — decided by
`summarise_verdict()`, a pure function of four counters. Every verdict line now names the
fraction measured, so a pass over three configs cannot read like a pass over seven:

```
Total: 7 | Measured: 3 | Regressions: 0 | Improvements: 0 | Skipped: 4
RESULT: PASSED -- 3 of 7 config(s) measured, all within tolerance (4 skipped)
```

- A measured regression outranks the empty case: 1 measured and regressed is `FAILED`, not
  `INCONCLUSIVE`.
- Configs of a kernel with no built executable are counted as skipped instead of leaving the
  denominator entirely.
- The two duplicate counter ladders are folded into one `tally()` closure, so the next bucket
  is added once rather than twice.

## The decision: warn, do not block

The issue's third acceptance criterion is that this be deliberate. It is, and it is recorded
in `AGENTS.md` beside the hook step table.

`INCONCLUSIVE` warns and allows the push. Blocking was rejected because the routine case on
this machine is already mostly skipped, so a blocking gate would reject ordinary pushes — and
the escape hatch from a blocking gate is `git push --no-verify`, which switches off **all
five** hook steps including the GPU-free R suites #163 exists to enforce. A warning that gets
read beats a block that gets bypassed.

All three callers read the same exit code: the hook warns, `make bench` warns, and
`scripts/probe/run_locked_eval.ps1` propagates it — right for a deliberate locked evaluation,
where measuring nothing must not read as success. Nothing in the repo parses the `RESULT`
line as text (verified by grep), so the rewording breaks no consumer.

If a binding signal is wanted here, that is #179, and it should be decided for the whole gate
rather than by tightening one exit code.

## Evidence — measured, not argued

| run | old code | new code |
|---|---|---|
| all-skip (`--kernel hgemm_16warp`, both configs clock-locked) | `Total: 2` → **PASSED**, exit 0 | `Total: 2 \| Measured: 0` → **INCONCLUSIVE**, exit 2 |
| unbuilt (executable moved aside) | `Total: 0` → **PASSED**, exit 0 | `Total: 1 \| Measured: 0` → **INCONCLUSIVE**, exit 2 |
| live full run | — | `Total: 7 \| Measured: 3` → **PASSED**, exit 0 |

Both "old code" rows are real runs of `git show main:scripts/bench/bench_regress.R`, not
reconstructions.

The hook's new branch was exercised end to end by running `.githooks/pre-push` unmodified
with a `PATH` shim that forces exit 2 for `bench_regress.R` only and delegates every other
`Rscript` call to the real interpreter.

## Tests

`tests/bench_regress/test_verdict.R` — 14 groups over the pure verdict function: an
all-skipped run is INCONCLUSIVE with a non-zero exit and its message contains neither
"PASSED" nor "within tolerance"; zero configs is not a vacuous pass; a partial run states its
fraction; a measured regression outranks a mostly-skipped run; the three exit codes stay
distinct, because two callers branch on the numbers.

**Proven able to fail.** Reinstating the bug (`if (measured < 1L)` → `if (FALSE)`) makes the
suite fail 2 groups and exit 1. The suite has no unconditional trailing success `cat()` — the
line that let the retired `test_parser.R` look green for 58 days (#171) — and no hardcoded
`/mnt/d/...` fallback (#173).

Adding a suite moves the outside denominator on purpose: `R_SUITES` 3 → 4 in the `Makefile`,
`--expect` and the `n_ok` assertion 3 → 4 in `tests.yml`. CI's skip count is unchanged at 4;
this suite skips nothing on a runner. Measured after the bump: `make test-r` is 4/4 PASSED in
117 s on AC.

## Review

Five independent lenses (R correctness, shell, gate integrity, tests, docs), each finding
raised then handed to a separate agent instructed to refute it. 21 raised, 9 survived,
deduplicating to six defects — all fixed here, in the fourth commit.

The two that mattered were both **the same bug as #176, one level out**: a signal meaning
"no measurement happened" arriving somewhere that read it as a measurement.

1. **`run_locked_eval.ps1` was not propagating the exit code at all** — the claim I had just
   written into four files. It sets `$PSNativeCommandUseErrorActionPreference = $true`, so on
   PowerShell 7 a non-zero exit from its `wsl.exe … Rscript` call throws
   `NativeCommandExitException` and skips `$BenchExit = $LASTEXITCODE`, the results record and
   `exit $BenchExit` outright. It reported **1 for both FAILED and INCONCLUSIVE** and wrote no
   record for exactly the runs that measured nothing. Reproduced independently on pwsh 7.6.3
   before fixing; a no-op on PS 5.1, which never threw. Now disabled around that one call and
   restored immediately after, verified 0 → 0, 1 → 1, 2 → 2 with the record written in all
   three cases.
2. **`Rscript` exits 2 when it cannot open the script file** — the same code as INCONCLUSIVE.
   My `make bench` recipe would have laundered a renamed or unreadable `bench_regress.R` into
   "nothing was measured, exit 0". Verified (`Rscript /nonexistent.R` → 2). Guarded with
   `test -r`: a missing gate is an error, not an empty measurement.

Also fixed: the suite tested only the pure verdict function, so it would have stayed green
against a `bench_regress.R` that still had the bug — there are now four end-to-end groups that
run the real script as a subprocess against a throwaway repo fixture (GPU-free: the
"benchmark" is a shell script printing one bench-shaped line, and the fixture disables the
fairness check so the result cannot depend on what the GPU is doing). All four assertions were
confirmed to fail against `main`'s code and pass against this branch. Plus three stale-text
fixes: the `--expect 3` comment in `tests.yml`, the hook's own step-table comment still calling
step 5 unqualified "blocking", and `CONTRIBUTING.md` describing only two outcomes.

Two confirmed findings were out of scope and are filed instead: **#183** (`bench_reference.R`
has both halves of this exact bug, and already `source()`s the fixed file) and **#184**
(`make reproduce` prints "results compared to data/baselines.json" unconditionally).

## Correction to the issue text

#176 says #156 put **4** of 7 configs behind `clock_lock`. `data/baselines.json` has **3**
(`hgemm_16warp` 2048³ and 4096³, `igemm_sparse_tiled` 4096³); the other four skips in the
pasted log were throttle, not the lock. The argument is unaffected — the measurable ceiling
for an ordinary push is 4 of 7, not 3 of 7.

## What this does not do

- Does not make any signal binding (#179).
- Does not address the inverse failure, false regressions on battery (#161).
- Does not change *why* configs skip — the clock-lock design from #156 and the throttle policy
  are untouched. It changes only what the gate is willing to claim afterwards.

Closes #176
