### PR TITLE
feat(viz): publish the research-map knowledge graph without the Google Fonts dependency (#192)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -283,10 +283,20 @@ jobs:
           # /bare-metal/viz/research-map/assets/...) has to be resolved against
           # _site with that prefix stripped, or every correctly-built asset
           # reads as missing.
+          # Must match `PAGES_BASE` in viz/research-map/vite.config.js. Two
+          # copies of one deployment prefix; if the repository is renamed both
+          # move, and the assertion below is what notices if only one does.
           BASE_PATH = "/bare-metal"
+          SITE_URL = "https://pjt222.github.io" + BASE_PATH
           def resolve(dirpath, target):
               if target.startswith("/"):
-                  rel = target[len(BASE_PATH):] if target.startswith(BASE_PATH + "/") else target
+                  # A site-absolute href WITHOUT the project prefix 404s on a
+                  # project page: the served root is /bare-metal/, not /. Return
+                  # a path that cannot exist so it is reported rather than
+                  # silently resolved against _site and passed.
+                  if not target.startswith(BASE_PATH + "/") and target != BASE_PATH:
+                      return os.path.join(root, "__missing_project_prefix__", target.lstrip("/"))
+                  rel = target[len(BASE_PATH):]
                   return os.path.normpath(os.path.join(root, rel.lstrip("/")))
               return os.path.normpath(os.path.join(dirpath, target))
           class P(HTMLParser):
@@ -301,6 +311,20 @@ jobs:
                   p = os.path.join(dp, f)
                   pr = P(); pr.feed(open(p, encoding="utf-8", errors="replace").read())
                   for ref in pr.refs:
+                      # An absolute URL pointing back at this site is a
+                      # link we can and should verify: the navbar's only entry
+                      # for the knowledge graph is one, so nothing would notice
+                      # if it were wrong.
+                      if ref.startswith(SITE_URL):
+                          checked += 1
+                          rel = ref[len(SITE_URL):].split("#")[0].split("?")[0].lstrip("/")
+                          cand = os.path.normpath(os.path.join(root, rel)) if rel else root
+                          if os.path.isdir(cand):
+                              if not os.path.exists(os.path.join(cand, "index.html")):
+                                  broken.append(f"{os.path.relpath(p, root)} -> {ref} (self URL, no index.html)")
+                          elif not os.path.exists(cand):
+                              broken.append(f"{os.path.relpath(p, root)} -> {ref} (self URL, missing)")
+                          continue
                       if re.match(r'^(https?:|mailto:|#|data:|//)', ref): continue
                       t = urllib.parse.unquote(ref.split("#")[0].split("?")[0])
                       if not t: continue

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -215,9 +215,26 @@ jobs:
             echo "::error::the viz build produced no index.html"; exit 1; }
           # The app must not reach off-origin to render: the rest of the site
           # does not, and a docs page should not require a third party to be up.
-          if grep -rqE 'https?://(fonts\.googleapis|fonts\.gstatic|cdn\.|unpkg|jsdelivr)' \
-               _site/viz/research-map/index.html _site/viz/research-map/assets/*.css; then
-            echo "::error::the published viz references a third-party origin"
+          #
+          # Scanned with find rather than a glob. `assets/*.css` matching nothing
+          # does not fail the step -- it prints "No such file or directory" and
+          # the guard reports success having read one file -- so a renamed asset
+          # layout would quietly narrow this to index.html alone.
+          #
+          # The JS bundle is included: an import from a CDN would never appear in
+          # the HTML or the CSS. The host pattern stays specific rather than
+          # "any URL" because the bundle legitimately contains http://www.w3.org
+          # (SVG namespace literals), which is not a network request.
+          viz_files=$(find _site/viz/research-map -type f \
+                        \( -name '*.html' -o -name '*.css' -o -name '*.js' \))
+          [ -n "$viz_files" ] || {
+            echo "::error::no viz html/css/js to scan — the copy produced nothing"
+            exit 1
+          }
+          echo "scanning $(echo "$viz_files" | wc -l) viz files for third-party origins"
+          if echo "$viz_files" | xargs grep -lE \
+               'https?://(fonts\.googleapis|fonts\.gstatic|cdn\.|unpkg\.|jsdelivr)'; then
+            echo "::error::the published viz references a third-party origin (files above)"
             exit 1
           fi
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -186,6 +186,41 @@ jobs:
       - name: Render the site
         run: quarto render --to html
 
+      # The interactive knowledge graph is a Vite + three.js app, published as a
+      # subdirectory of this site (#192). It is built here rather than committed:
+      # viz/research-map/dist/ is gitignored (viz/.gitignore:2).
+      #
+      # GITHUB_ACTIONS is what switches vite.config.js to the /bare-metal/ base,
+      # so the emitted asset paths resolve under a project page. The same
+      # env-driven switch is what the sibling project ez-ar2diff uses.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: viz/research-map/package-lock.json
+
+      - name: Build the research-map knowledge graph
+        working-directory: viz/research-map
+        run: |
+          npm ci
+          npm run build
+
+      # Into _site BEFORE the assertions and the link check below, so the
+      # published bundle is covered by both rather than bolted on afterwards.
+      - name: Place the knowledge graph in the site
+        run: |
+          mkdir -p _site/viz/research-map
+          cp -r viz/research-map/dist/. _site/viz/research-map/
+          test -f _site/viz/research-map/index.html || {
+            echo "::error::the viz build produced no index.html"; exit 1; }
+          # The app must not reach off-origin to render: the rest of the site
+          # does not, and a docs page should not require a third party to be up.
+          if grep -rqE 'https?://(fonts\.googleapis|fonts\.gstatic|cdn\.|unpkg|jsdelivr)' \
+               _site/viz/research-map/index.html _site/viz/research-map/assets/*.css; then
+            echo "::error::the published viz references a third-party origin"
+            exit 1
+          fi
+
       # Assert the build produced a site rather than exiting 0 having produced
       # nothing — the same reasoning as the gate assertions in tests.yml. A
       # deploy step will happily publish an empty directory.
@@ -201,7 +236,8 @@ jobs:
             docs/benchmark_methodology.html docs/ampere_sass_reference.html \
             docs/tutorial/01-sass-hello-world.html \
             docs/tutorial/06-the-four-laws.html \
-            docs/analysis/kernel_architecture.html
+            docs/analysis/kernel_architecture.html \
+            viz/research-map/index.html
           do
             [ -f "_site/$page" ] || { echo "::error::missing _site/$page"; missing=1; }
           done
@@ -225,6 +261,17 @@ jobs:
           from html.parser import HTMLParser
           root = "_site"; broken = []; checked = 0
           SOURCE_EXT = {".md", ".qmd", ".rmd", ".r", ".ipynb"}
+          # This is a GitHub *project* page, so the served root is /bare-metal/,
+          # not /. A site-absolute href (the Vite bundle emits
+          # /bare-metal/viz/research-map/assets/...) has to be resolved against
+          # _site with that prefix stripped, or every correctly-built asset
+          # reads as missing.
+          BASE_PATH = "/bare-metal"
+          def resolve(dirpath, target):
+              if target.startswith("/"):
+                  rel = target[len(BASE_PATH):] if target.startswith(BASE_PATH + "/") else target
+                  return os.path.normpath(os.path.join(root, rel.lstrip("/")))
+              return os.path.normpath(os.path.join(dirpath, target))
           class P(HTMLParser):
               def __init__(s): super().__init__(); s.refs = []
               def handle_starttag(s, t, a):
@@ -241,7 +288,7 @@ jobs:
                       t = urllib.parse.unquote(ref.split("#")[0].split("?")[0])
                       if not t: continue
                       checked += 1
-                      full = os.path.normpath(os.path.join(dp, t))
+                      full = resolve(dp, t)
                       # A directory is NOT a servable target: GitHub Pages does
                       # not list directories, it serves index.html or 404s. A
                       # bare os.path.exists() call passes those, which is how

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -59,6 +59,12 @@ website:
           - docs/tutorial/06-the-four-laws.md
       - text: "Analysis"
         href: docs/analysis/kernel_architecture.qmd
+      # Absolute URL on purpose: a relative link would make Quarto resolve the
+      # app against the SOURCE tree and copy its unbuilt index.html into the
+      # site, which is exactly how #187 ended up publishing a broken copy. The
+      # bundle is placed into _site by the workflow, after the render.
+      - text: "Knowledge graph"
+        href: "https://pjt222.github.io/bare-metal/viz/research-map/"
     right:
       - icon: github
         href: https://github.com/pjt222/bare-metal

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ Each subdirectory is a standalone application with its own
 
 | Subdirectory                                         | Stack          | Purpose                                            |
 |------------------------------------------------------|----------------|----------------------------------------------------|
-| [`viz/research-map/`](https://github.com/pjt222/bare-metal/tree/main/viz/research-map)       | Vite + three.js | Interactive knowledge graph of the project's optimization observations and their cross-references |
+| [`viz/research-map/`](https://pjt222.github.io/bare-metal/viz/research-map/) | Vite + three.js | Interactive knowledge graph of the project's optimization observations and their cross-references — **[open it](https://pjt222.github.io/bare-metal/viz/research-map/)**, [source](https://github.com/pjt222/bare-metal/tree/main/viz/research-map) |
 
 To run a viz locally:
 

--- a/viz/research-map/index.html
+++ b/viz/research-map/index.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GPU Research Knowledge Graph</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/src/style.css" />
+  <!-- No webfont links. This page is published as part of the documentation
+       site (#192), and the rest of that site makes no third-party requests;
+       rendering a page should not require calling out to Google. The two font
+       stacks live in src/style.css and resolve entirely on the reader's
+       machine. -->
+  <link rel="stylesheet" href="./src/style.css" />
 </head>
 <body>
   <div id="app">
@@ -23,6 +25,6 @@
     </div>
     <div id="tooltip" class="hidden"></div>
   </div>
-  <script type="module" src="/src/main.js"></script>
+  <script type="module" src="./src/main.js"></script>
 </body>
 </html>

--- a/viz/research-map/src/style.css
+++ b/viz/research-map/src/style.css
@@ -16,8 +16,15 @@
   --text-primary: #f1f5f9;
   --text-secondary: #94a3b8;
   --text-mono: #a5f3fc;
-  --font-sans: 'Inter', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  /* System stacks, deliberately (#192): Inter and JetBrains Mono were loaded
+     from fonts.googleapis.com, and this page is now served from the project's
+     own documentation site, which makes no third-party requests. Both stacks
+     already ended in a generic family, so the rendered result was always these
+     faces for anyone the webfont failed to reach. */
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+               Arial, "Noto Sans", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+               "Liberation Mono", "Courier New", monospace;
 
   /* Phase colors */
   --phase1: #6366f1;

--- a/viz/research-map/vite.config.js
+++ b/viz/research-map/vite.config.js
@@ -21,6 +21,11 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    sourcemap: true,
+    // Sourcemaps locally, not in the published bundle. The map is 1.99 MB
+    // against a 490 KB bundle — 80% of what a reader downloads — and the
+    // unminified source it reconstructs is a click away in the repository this
+    // page links to. Keep them for local debugging, where that trade does not
+    // apply.
+    sourcemap: !isGitHubPages,
   },
 });

--- a/viz/research-map/vite.config.js
+++ b/viz/research-map/vite.config.js
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vite';
 
+// The knowledge graph is published as a subdirectory of the documentation site
+// (#192), which is a GitHub *project* page served from /bare-metal/ — not from a
+// domain root. Without a matching `base`, Vite emits absolute asset paths like
+// /assets/index-*.js, which 404 under that prefix. That is the same mechanism
+// that made this app's source index.html unservable when Quarto copied it into
+// the site during #187.
+//
+// Switched on GITHUB_ACTIONS so a local `npm run dev` / `npm run build` keeps
+// working from the filesystem root, matching the pattern the sibling project
+// ez-ar2diff uses in its viz/vite.config.js.
+const PAGES_BASE = '/bare-metal/viz/research-map/';
+const isGitHubPages = process.env.GITHUB_ACTIONS === 'true';
+
 export default defineConfig({
+  base: isGitHubPages ? PAGES_BASE : '/',
   server: {
     port: 5173,
     strictPort: false,


### PR DESCRIPTION
## What was missing

The #187 site shipped **16 visualisations** — 9 static figures under `docs/figures/` (including
the cymatic/Chladni set) and 7 plots generated inside the kernel architecture analysis — and not
the interactive one.

`viz/research-map/` was excluded there for a concrete reason: Quarto had been copying the app's
**source** `index.html` into the site as a linked resource, where its absolute `/src/style.css`
and `/src/main.js` paths 404. That was two of the three broken links in the first #187 build.

## What publishing it took

**A Vite `base`.** The app emitted `/assets/index-*.js`, which 404s under a project page served
from `/bare-metal/`. `vite.config.js` now switches on `GITHUB_ACTIONS` between `/` locally and
`/bare-metal/viz/research-map/` for the published build — the same env-driven switch the sibling
project **`ez-ar2diff`** uses in its `viz/vite.config.js`. A local `npm run build` still emits
root-relative paths, so development is unchanged:

```
local :  src="/assets/index-ydvVbT6x.js"
CI    :  src="/bare-metal/viz/research-map/assets/index-ydvVbT6x.js"
```

**A build step.** `viz/research-map/dist/` is gitignored (`viz/.gitignore:2`), so there was no
bundle to publish. The `site` job gains `actions/setup-node` with npm caching keyed on the
lockfile, `npm ci && npm run build`, and a copy into `_site/viz/research-map/` — placed **before**
the build assertions and the link check, so the bundle is covered by both rather than bolted on
after them.

**No Google Fonts.** `index.html` preconnected to `fonts.googleapis.com` / `fonts.gstatic.com` and
pulled Inter + JetBrains Mono from them. The rest of the site makes no third-party requests, and
rendering a docs page should not require Google to be up. Both faces were referenced only through
`--font-sans` / `--font-mono`, so they are now system stacks — every reader whose webfont request
had ever failed was already seeing exactly these. The workflow greps the published bundle for
third-party origins and fails if one reappears, so the dependency cannot return unnoticed.

**A link that does not re-trigger the resource copy.** The navbar entry and the `docs/index.md`
row use the absolute public URL. A relative path would make Quarto resolve the app against the
source tree and copy the unbuilt `index.html` in again — the #187 failure exactly.

## The link checker had to learn what a project page is

It resolved every site-absolute href against the filesystem root, so the *correctly built* bundle's
`/bare-metal/viz/research-map/assets/...` paths read as missing. It now strips the base prefix
before resolving.

Found by running the check against a real placed build rather than by reasoning about it — the
first local run reported 2 broken links pointing at the app's own assets.

## Prior art consulted

| repo | approach |
|---|---|
| **`ez-ar2diff`** | `deploy-viz.yml` — Node 20, `npm ci`, `npm run build`, `base` switched on `GITHUB_ACTIONS`. Closest match; the `base` trick is taken from here |
| `agent-almanac`, `multiplex` | `deploy-pages.yml` / `deploy-gh-pages.yml` |
| `jigsawR` | `quarto-publish.yml` — same Quarto family as this repo |
| `putior`, `spiralizer`, `cardcertr`, `emlR` | `pkgdown` for R packages |

The difference here is that this site is a Quarto site **plus** the viz as a subdirectory, rather
than the viz being the whole site — so the bundle lands inside `_site/` before the assertions run.

## Verified locally, end to end

- **37 pages**, **1240 internal links, 0 broken** under the strict rule (directories without
  `index.html`, and links to unrendered source files, both count as broken)
- **no external origin** in the published app — `grep` over the bundle's HTML and CSS returns nothing
- a local build still emits `/assets/...`, so `npm run dev` is unaffected

Closes #192